### PR TITLE
main: list-images takes no args (just --filter)

### DIFF
--- a/cmd/image-builder/main.go
+++ b/cmd/image-builder/main.go
@@ -64,6 +64,7 @@ operating sytsems like centos and RHEL with easy customizations support.`,
 		Short:        "List buildable images, use --filter to limit further",
 		RunE:         cmdListImages,
 		SilenceUsage: true,
+		Args:         cobra.NoArgs,
 	}
 	listImagesCmd.Flags().StringArray("filter", nil, `Filter distributions by a specific criteria (e.g. "type:rhel*")`)
 	listImagesCmd.Flags().String("output", "", "Output in a specific format (text, json)")

--- a/cmd/image-builder/main_test.go
+++ b/cmd/image-builder/main_test.go
@@ -108,3 +108,18 @@ func TestListImagesOverrideDatadir(t *testing.T) {
 	err := main.Run()
 	assert.EqualError(t, err, `no repositories found in the given paths: [/this/path/does/not/exist]`)
 }
+
+func TestListImagesErrorsOnExtraArgs(t *testing.T) {
+	restore := main.MockNewRepoRegistry(testrepos.New)
+	defer restore()
+
+	restore = main.MockOsArgs(append([]string{"list-images"}, "extra-arg"))
+	defer restore()
+
+	var fakeStdout bytes.Buffer
+	restore = main.MockOsStdout(&fakeStdout)
+	defer restore()
+
+	err := main.Run()
+	assert.EqualError(t, err, `unknown command "extra-arg" for "image-builder list-images"`)
+}


### PR DESCRIPTION
Tiny commit to error if extra arguments are passed to list-images. Only `--filter` is supported there currently.