### PR TITLE
cmd: add new `build` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ $ sudo dnf install osbuild osbuild-depsolve-dnf osbuild-composer
 (`osbuild-composer` is only needed to get the repository definitions
 and this dependency will go away soon).
 
-## Example
+## Examples
 
 To see the list of buildable images run:
 ```console
@@ -36,6 +36,15 @@ centos-9 type:qcow2 arch:x86_64
 rhel-10.0 type:ami arch:x86_64
 ...
 ```
+
+To actually build an image run:
+```console
+$ sudo image-builder build qcow2 --distro centos-9
+...
+```
+this will create a directory `centos-9-qcow2-x86_64` under which the
+output is stored.
+
 
 It is possible to filter:
 ```console

--- a/cmd/image-builder/build.go
+++ b/cmd/image-builder/build.go
@@ -1,0 +1,24 @@
+package main
+
+import (
+	"fmt"
+	"path/filepath"
+
+	"github.com/osbuild/images/pkg/imagefilter"
+	"github.com/osbuild/images/pkg/osbuild"
+)
+
+func buildImage(res *imagefilter.Result, osbuildManifest []byte) error {
+	osbuildStoreDir := ".store"
+	// XXX: support output dir via commandline
+	// XXX2: support output filename via commandline (c.f.
+	//   https://github.com/osbuild/images/pull/1039)
+	outputDir := "."
+	buildName := fmt.Sprintf("%s-%s-%s", res.Distro.Name(), res.ImgType.Name(), res.Arch.Name())
+	jobOutputDir := filepath.Join(outputDir, buildName)
+
+	// XXX: support stremaing via images/pkg/osbuild/monitor.go
+	_, err := osbuild.RunOSBuild(osbuildManifest, osbuildStoreDir, jobOutputDir, res.ImgType.Exports(), nil, nil, false, osStderr)
+	return err
+
+}

--- a/cmd/image-builder/manifest.go
+++ b/cmd/image-builder/manifest.go
@@ -1,0 +1,30 @@
+package main
+
+import (
+	"io"
+
+	"github.com/osbuild/images/pkg/imagefilter"
+
+	"github.com/osbuild/image-builder-cli/internal/blueprintload"
+	"github.com/osbuild/image-builder-cli/internal/manifestgen"
+)
+
+func generateManifest(dataDir, blueprintPath string, res *imagefilter.Result, output io.Writer) error {
+	repos, err := newRepoRegistry(dataDir)
+	if err != nil {
+		return err
+	}
+	// XXX: add --rpmmd/cachedir option like bib
+	mg, err := manifestgen.New(repos, &manifestgen.Options{
+		Output: output,
+	})
+	if err != nil {
+		return err
+	}
+	bp, err := blueprintload.Load(blueprintPath)
+	if err != nil {
+		return err
+	}
+
+	return mg.Generate(bp, res.Distro, res.ImgType, res.Arch, nil)
+}

--- a/internal/testutil/testutil.go
+++ b/internal/testutil/testutil.go
@@ -1,0 +1,62 @@
+package testutil
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+type MockCmd struct {
+	binDir string
+	name   string
+}
+
+func MockCommand(t *testing.T, name string, script string) *MockCmd {
+	mockCmd := &MockCmd{
+		binDir: t.TempDir(),
+		name:   name,
+	}
+
+	fullScript := `#!/bin/bash -e
+for arg in "$@"; do
+   echo -e -n "$arg\x0" >> "$0".run
+done
+echo >> "$0".run
+` + script
+
+	t.Setenv("PATH", mockCmd.binDir+":"+os.Getenv("PATH"))
+	err := os.WriteFile(filepath.Join(mockCmd.binDir, name), []byte(fullScript), 0755)
+	require.NoError(t, err)
+
+	return mockCmd
+}
+
+func (mc *MockCmd) Path() string {
+	return filepath.Join(mc.binDir, mc.name)
+}
+
+func (mc *MockCmd) Restore() error {
+	return os.RemoveAll(mc.binDir)
+}
+
+func (mc *MockCmd) Calls() [][]string {
+	b, err := os.ReadFile(mc.Path() + ".run")
+	if os.IsNotExist(err) {
+		return nil
+	}
+	if err != nil {
+		panic(err)
+	}
+	var calls [][]string
+	for _, line := range strings.Split(string(b), "\n") {
+		if line == "" {
+			continue
+		}
+		call := strings.Split(line, "\000")
+		calls = append(calls, call[0:len(call)-1])
+	}
+	return calls
+}

--- a/internal/testutil/testutil_test.go
+++ b/internal/testutil/testutil_test.go
@@ -1,0 +1,25 @@
+package testutil_test
+
+import (
+	"os/exec"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/osbuild/image-builder-cli/internal/testutil"
+)
+
+func TestMockCommand(t *testing.T) {
+	fakeCmd := testutil.MockCommand(t, "false", "exit 0")
+	defer fakeCmd.Restore()
+
+	err := exec.Command("false", "run1-arg1", "run1-arg2").Run()
+	assert.NoError(t, err)
+	err = exec.Command("false", "run2-arg1", "run2-arg2").Run()
+	assert.NoError(t, err)
+
+	assert.Equal(t, [][]string{
+		{"run1-arg1", "run1-arg2"},
+		{"run2-arg1", "run2-arg2"},
+	}, fakeCmd.Calls())
+}


### PR DESCRIPTION
This commit adds the `build` command. It takes the same flags as
`manifest` and will build the specified image.

E.g.
```console
$ image-builder-cli build --distro centos-9 qcow2
...
```