### PR TITLE
misc: add Containerfile

### DIFF
--- a/.github/workflows/container.yaml
+++ b/.github/workflows/container.yaml
@@ -1,0 +1,48 @@
+name: Build & Deploy Container
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+  merge_group:
+    types: [ "checks_requested" ]
+
+jobs:
+  build-base:
+    name: Build & push image
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Login to Github Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Generate container image metadata
+        uses: docker/metadata-action@v4
+        id: meta
+        with:
+          images: ghcr.io/osbuild/image-builder-cli
+          tags: |
+            type=ref,event=tag,enable=${{ startsWith(github.ref, 'refs/tags/') }}
+            type=raw,value=latest
+            type=sha,format=long,enable=${{ github.ref == 'refs/heads/main' }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          platforms: linux/amd64
+          file: ./Containerfile
+          push: ${{ github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/') }}
+          cache-from: type=registry,ref=ghcr.io/osbuild/image-builder-cli:latest
+          cache-to: type=inline
+          tags: ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -13,6 +13,7 @@ jobs:
 
   build:
     runs-on: ubuntu-latest
+    uses:  ./.github/workflows/testdeps.yml
     steps:
     - uses: actions/checkout@v4
 
@@ -21,13 +22,6 @@ jobs:
       with:
         go-version: 'stable'
         
-    - name: Apt update
-      run: sudo apt update
-
-    # This is needed for the container resolver dependencies
-    - name: Install test dependencies
-      run: sudo apt install -y libgpgme-dev libbtrfs-dev libdevmapper-dev podman
-
     - name: Build
       run: go build -v ./...
 

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -1,0 +1,24 @@
+name: Integration tests
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    uses:  ./.github/workflows/testdeps.yml
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Install integration test env
+      run: |
+        sudo apt update
+        sudo apt install -y pytest golang
+
+    - name: Run integration tests via pytest
+      run: |
+        # use "-s" for now for easier debugging
+        sudo pytest -s -v

--- a/.github/workflows/testdeps.yml
+++ b/.github/workflows/testdeps.yml
@@ -1,10 +1,13 @@
-name: Install test dependencies
+name: Install common test dependencies
+
+on:
+  workflow_call:
 
 jobs:
   install:
     runs-on: ubuntu-latest
     steps:
-      - name: Install test dependencies
+      - name: Install common test dependencies
         run: |
           sudo apt update
           sudo apt install -y libgpgme-dev libbtrfs-dev libdevmapper-dev podman

--- a/.github/workflows/testdeps.yml
+++ b/.github/workflows/testdeps.yml
@@ -1,0 +1,10 @@
+name: Install test dependencies
+
+jobs:
+  install:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install test dependencies
+        run: |
+          sudo apt update
+          sudo apt install -y libgpgme-dev libbtrfs-dev libdevmapper-dev podman

--- a/Containerfile
+++ b/Containerfile
@@ -48,8 +48,8 @@ COPY entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]
 VOLUME /output
 WORKDIR /output
+# XXX: add "store" flag like bib
 VOLUME /store
-VOLUME /rpmmd
 VOLUME /var/lib/containers/storage
 
 LABEL description="This tools allows to build and deploy disk-images."

--- a/Containerfile
+++ b/Containerfile
@@ -1,0 +1,59 @@
+FROM registry.fedoraproject.org/fedora:41 AS builder
+RUN dnf install -y git-core golang gpgme-devel libassuan-devel && mkdir -p /build/
+ARG GOPROXY=https://proxy.golang.org,direct
+RUN go env -w GOPROXY=$GOPROXY
+COPY . /build
+WORKDIR /build
+# keep in sync with:
+# https://github.com/containers/podman/blob/2981262215f563461d449b9841741339f4d9a894/Makefile#L51
+RUN go build -tags "containers_image_openpgp exclude_graphdriver_btrfs exclude_graphdriver_devicemapper" ./cmd/image-builder
+
+FROM registry.fedoraproject.org/fedora:41
+
+# Fast-track osbuild so we don't depend on the "slow" Fedora release process to implement new features in bib
+RUN dnf install -y dnf-plugins-core \
+    && dnf copr enable -y @osbuild/osbuild \
+    && dnf install -y libxcrypt-compat wget osbuild osbuild-ostree osbuild-depsolve-dnf osbuild-lvm2 \
+    && dnf clean all
+
+COPY --from=builder /build/image-builder /usr/bin/
+
+# install repo data from osbuild-composer in an ugly way
+# XXX: find a better way
+RUN <<EOR
+ mkdir -p /usr/share/osbuild-composer/repositories
+ cd /usr/share/osbuild-composer/repositories
+ # XXX: find a better way to organize the upstream supported repos
+ # we cannot just checkout the osbuild-composer repo here as it contains a bunch
+ # of "*-no-aux-key.json" files too, so a naive "cp *.json" will not work.
+ # Ideally we split the supported repos out of osbuild-composer into
+ # either "images" (as it generates the code for supported distro it could
+ # be the place that also defines what is supported) or into its own repo.
+ # Bonus points if we could make them go:embedable :)
+ for fname in centos-stream-9 centos-stream-10 \
+              fedora-40 fedora-41 \
+              rhel-8 rhel-8.1 rhel-8.2 rhel-8.3 rhel-8.4 rhel-8.5 rhel-8.6 \
+	      rhel-8.7 rhel-8.8 rhel-8.9 \
+	      rhel-9.0 rhel-9.1 rhel-9.2 rhel-9.3 rhel-9.4 rhel-9.5 rhel-9.6 \
+	      rhel-10.0; do
+   # XXX: if only we had 'go:embed'able repos :(
+   wget https://raw.githubusercontent.com/osbuild/osbuild-composer/refs/heads/main/repositories/${fname}.json
+ done
+ # XXX: find an even better way here, those are symlinks in the upstream repo
+ cp -a centos-stream-9.json centos-9.json
+ cp -a centos-stream-10.json centos-10.json
+EOR
+
+COPY entrypoint.sh /entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]
+VOLUME /output
+WORKDIR /output
+VOLUME /store
+VOLUME /rpmmd
+VOLUME /var/lib/containers/storage
+
+LABEL description="This tools allows to build and deploy disk-images."
+LABEL io.k8s.description="This tools allows to build and deploy disk-images."
+LABEL io.k8s.display-name="Image Builder"
+LABEL io.openshift.tags="base fedora40"
+LABEL summary="A container to create disk-images."

--- a/README.md
+++ b/README.md
@@ -2,6 +2,17 @@
 
 Build images from the commandline in a convenient way.
 
+## Run via container
+
+```console
+$ sudo podman run --privileged \
+   -v ./output:/output \
+   ghcr.io/osbuild/image-builder-cli:latest \
+   build \
+   --distro fedora-41 \
+   minimal-raw
+```
+
 ## Installation
 
 This project is under development right now and needs to be run via:

--- a/cmd/image-builder/build.go
+++ b/cmd/image-builder/build.go
@@ -8,8 +8,7 @@ import (
 	"github.com/osbuild/images/pkg/osbuild"
 )
 
-func buildImage(res *imagefilter.Result, osbuildManifest []byte) error {
-	osbuildStoreDir := ".store"
+func buildImage(res *imagefilter.Result, osbuildManifest []byte, osbuildStoreDir string) error {
 	// XXX: support output dir via commandline
 	// XXX2: support output filename via commandline (c.f.
 	//   https://github.com/osbuild/images/pull/1039)

--- a/cmd/image-builder/main.go
+++ b/cmd/image-builder/main.go
@@ -88,8 +88,12 @@ func cmdManifest(cmd *cobra.Command, args []string) error {
 }
 
 func cmdBuild(cmd *cobra.Command, args []string) error {
-	var mf bytes.Buffer
+	storeDir, err := cmd.Flags().GetString("store")
+	if err != nil {
+		return err
+	}
 
+	var mf bytes.Buffer
 	// XXX: check env here, i.e. if user is root and osbuild is installed
 	res, err := cmdManifestWrapper(cmd, args, &mf, func(archStr string) error {
 		if archStr != arch.Current().String() {
@@ -101,7 +105,7 @@ func cmdBuild(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	return buildImage(res, mf.Bytes())
+	return buildImage(res, mf.Bytes(), storeDir)
 }
 
 func run() error {
@@ -154,6 +158,7 @@ operating sytsems like centos and RHEL with easy customizations support.`,
 		Args:         cobra.RangeArgs(1, 2),
 	}
 	buildCmd.Flags().AddFlagSet(manifestCmd.Flags())
+	buildCmd.Flags().String("store", ".store", `osbuild store directory to cache intermediata build artifacts"`)
 	rootCmd.AddCommand(buildCmd)
 
 	return rootCmd.Execute()

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,24 @@
+#!/bin/sh
+
+set -e
+
+# TODO: share code with bib to do the setup automatically
+# see https://github.com/teamsbc/container-for-osbuild/blob/main/entrypoint.bash (thanks simon)
+# and https://github.com/osbuild/bootc-image-builder/blob/main/bib/internal/setup/setup.go#L21 (thanks ondrej,achilleas,colin)
+mkdir /run/osbuild
+mkdir /run/osbuild-store
+
+mount -t tmpfs tmpfs /run/osbuild
+mount -t tmpfs tmpfs /run/osbuild-store
+
+cp -p /usr/bin/osbuild /run/osbuild/osbuild
+
+chcon system_u:object_r:root_t:s0 /run/osbuild-store
+chcon system_u:object_r:install_exec_t:s0 /run/osbuild/osbuild
+
+mount -t devtmpfs devtmpfs /dev
+mount --bind /run/osbuild/osbuild /usr/bin/osbuild
+
+# XXX: make this nicer
+cd /output
+/usr/bin/image-builder --store=/store "$@"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -9,11 +9,9 @@ mkdir /run/osbuild
 mkdir /run/osbuild-store
 
 mount -t tmpfs tmpfs /run/osbuild
-mount -t tmpfs tmpfs /run/osbuild-store
 
 cp -p /usr/bin/osbuild /run/osbuild/osbuild
 
-chcon system_u:object_r:root_t:s0 /run/osbuild-store
 chcon system_u:object_r:install_exec_t:s0 /run/osbuild/osbuild
 
 mount -t devtmpfs devtmpfs /dev

--- a/internal/manifestgen/manifestgen.go
+++ b/internal/manifestgen/manifestgen.go
@@ -22,6 +22,15 @@ import (
 // into a common helper in "images" or images should do this on its
 // own
 func defaultDepsolver(cacheDir string, packageSets map[string][]rpmmd.PackageSet, d distro.Distro, arch string) (map[string][]rpmmd.PackageSpec, map[string][]rpmmd.RepoConfig, error) {
+	if cacheDir == "" {
+		var err error
+		cacheDir, err = os.MkdirTemp("", "manifestgen")
+		if err != nil {
+			return nil, nil, fmt.Errorf("cannot create temporary directory: %w", err)
+		}
+		defer os.RemoveAll(cacheDir)
+	}
+
 	solver := dnfjson.NewSolver(d.ModulePlatformID(), d.Releasever(), arch, d.Name(), cacheDir)
 	depsolvedSets := make(map[string][]rpmmd.PackageSpec)
 	repoSets := make(map[string][]rpmmd.RepoConfig)

--- a/test/containerbuild.py
+++ b/test/containerbuild.py
@@ -1,0 +1,23 @@
+import os
+import platform
+import random
+import string
+import subprocess
+import textwrap
+from contextlib import contextmanager
+
+import pytest
+
+
+# XXX: copied from bib
+@pytest.fixture(name="build_container", scope="session")
+def build_container_fixture():
+    """Build a container from the Containerfile and returns the name"""
+
+    container_tag = "image-builder-cli-test"
+    subprocess.check_call([
+        "podman", "build",
+        "-f", "Containerfile",
+        "-t", container_tag,
+    ])
+    return container_tag

--- a/test/test_container.py
+++ b/test/test_container.py
@@ -1,0 +1,27 @@
+import os
+import subprocess
+
+import pytest
+
+from containerbuild import build_container_fixture
+
+
+@pytest.mark.skipif(os.getuid() != 0, reason="needs root")
+def test_container_builds_image(tmp_path, build_container):
+    output_dir = tmp_path / "output"
+    output_dir.mkdir()
+    subprocess.check_call([
+        "podman", "run",
+        "--privileged",
+        "-v", f"{output_dir}:/output",
+        build_container,
+        "build",
+        "minimal-raw",
+        "--distro", "fedora-41"
+    ])
+    arch = "x86_64"
+    assert (output_dir / f"fedora-41-minimal-raw-{arch}/xz/disk.raw.xz").exists()
+    # XXX: ensure no other leftover dirs
+    dents = os.listdir(output_dir)
+    assert len(dents) == 1, f"too many dentries in output dir: {dents}"
+


### PR DESCRIPTION
This PR adds Containerfile integration, with that a bib style deploy/run is possible. The Containerfile is pretty nasty right now, especially around the "getting supported repositories" part. This needs to get fixed either in composer or images IMHO (or via go:embed). But with that we can give it to our early users and let them play with building images.

It also contains automatic container building as part of the GH action (thanks @supakeen!) and once we have it we can update the README to point to the auto-generated containers for even easier testing/using.

As is "list-images" and "manifest" will work but once #8 is merged the below works (on my local system, we want tests here :)

Run build via container, bib-style:
```console
$ sudo podman build . -t test-icbli
$ sudo podman run --privileged \
   -v ./output:/output \
   test-ibcli:latest \
   build \
   --distro fedora-41 \
   minimal-raw
```
