### PR TITLE
ibcli: use `/var/cache/image-builder/store` as default for `--store`

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -49,7 +49,7 @@ ENTRYPOINT ["/entrypoint.sh"]
 VOLUME /output
 WORKDIR /output
 # XXX: add "store" flag like bib
-VOLUME /store
+VOLUME /var/cache/image-builder/store
 VOLUME /var/lib/containers/storage
 
 LABEL description="This tools allows to build and deploy disk-images."

--- a/cmd/image-builder/main.go
+++ b/cmd/image-builder/main.go
@@ -158,7 +158,8 @@ operating sytsems like centos and RHEL with easy customizations support.`,
 		Args:         cobra.RangeArgs(1, 2),
 	}
 	buildCmd.Flags().AddFlagSet(manifestCmd.Flags())
-	buildCmd.Flags().String("store", ".store", `osbuild store directory to cache intermediata build artifacts"`)
+	// XXX: add --rpmmd cache too and put under /var/cache/image-builder/dnf
+	buildCmd.Flags().String("store", "/var/cache/image-builder/store", `osbuild store directory to cache intermediata build artifacts"`)
 	rootCmd.AddCommand(buildCmd)
 
 	return rootCmd.Execute()

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -6,7 +6,6 @@ set -e
 # see https://github.com/teamsbc/container-for-osbuild/blob/main/entrypoint.bash (thanks simon)
 # and https://github.com/osbuild/bootc-image-builder/blob/main/bib/internal/setup/setup.go#L21 (thanks ondrej,achilleas,colin)
 mkdir /run/osbuild
-mkdir /run/osbuild-store
 
 mount -t tmpfs tmpfs /run/osbuild
 
@@ -19,4 +18,4 @@ mount --bind /run/osbuild/osbuild /usr/bin/osbuild
 
 # XXX: make this nicer
 cd /output
-/usr/bin/image-builder --store=/store "$@"
+/usr/bin/image-builder "$@"


### PR DESCRIPTION
This commit follows a suggestion from Ondrej to add a better default for `--store`: /var/cache/image-builder/store.

This is nice as it will give users automatic caching and makes the container also nicer.