### PR TITLE
test: move to `centos-9` for the smoke test

### DIFF
--- a/test/test_container.py
+++ b/test/test_container.py
@@ -17,7 +17,7 @@ def test_container_builds_image(tmp_path, build_container):
         build_container,
         "build",
         "minimal-raw",
-        "--distro", "fedora-41"
+        "--distro", "centos-9"
     ])
     arch = "x86_64"
     assert (output_dir / f"fedora-41-minimal-raw-{arch}/xz/disk.raw.xz").exists()


### PR DESCRIPTION
This commit moves the smoke test from fedora-41 to centos-9. The reason is that it seems the fedora mirrors in general are a bit more flaky so /hopefully/ the centos one will help.

The real fix of course is to retry different mirrors on failure, we will need to look into librepo integration in osbuild (again) for this (hopefully soon!).