### PR TITLE
workflow: run tests as part of the merge group

### DIFF
--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -8,6 +8,8 @@ on:
     branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
+  merge_group:
+    types: [ "checks_requested" ]
 
 jobs:
 

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -5,6 +5,8 @@ on:
     branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
+  merge_group:
+    types: [ "checks_requested" ]
 
 jobs:
   build:


### PR DESCRIPTION
This commit adds the missing `merge_group` to the pytest and go test workflows.

Note that I added `types: [ "checks_requested" ]` (just like we have for the container.yaml) but I'm not actually sure about it, the GH docs are a bit unclear to me here, it seems they suggest to keep this generic but then the example explicitly uses `type` (I'm probably overthinking this fwiw).

[1] https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#merge_group