### PR TITLE
main: add --progres (similar to bib)

### DIFF
--- a/cmd/image-builder/build.go
+++ b/cmd/image-builder/build.go
@@ -5,8 +5,8 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/osbuild/bootc-image-builder/bib/pkg/progress"
 	"github.com/osbuild/images/pkg/imagefilter"
-	"github.com/osbuild/images/pkg/osbuild"
 )
 
 type buildOptions struct {
@@ -16,7 +16,7 @@ type buildOptions struct {
 	WriteManifest bool
 }
 
-func buildImage(res *imagefilter.Result, osbuildManifest []byte, opts *buildOptions) error {
+func buildImage(pbar progress.ProgressBar, res *imagefilter.Result, osbuildManifest []byte, opts *buildOptions) error {
 	if opts == nil {
 		opts = &buildOptions{}
 	}
@@ -36,8 +36,5 @@ func buildImage(res *imagefilter.Result, osbuildManifest []byte, opts *buildOpti
 		}
 	}
 
-	// XXX: support stremaing via images/pkg/osbuild/monitor.go
-	_, err := osbuild.RunOSBuild(osbuildManifest, opts.StoreDir, opts.OutputDir, res.ImgType.Exports(), nil, nil, false, osStderr)
-	return err
-
+	return progress.RunOSBuild(pbar, osbuildManifest, opts.StoreDir, opts.OutputDir, res.ImgType.Exports(), nil)
 }

--- a/go.mod
+++ b/go.mod
@@ -2,11 +2,14 @@ module github.com/osbuild/image-builder-cli
 
 // keep in sync with images,
 // c.f. https://github.com/osbuild/images/blob/main/go.mod
-go 1.21.0
+go 1.22.0
+
+toolchain go1.22.2
 
 require (
 	github.com/BurntSushi/toml v1.4.0
 	github.com/gobwas/glob v0.2.3
+	github.com/osbuild/bootc-image-builder/bib v0.0.0-20250125114430-c5d674173ba0
 	github.com/osbuild/images v0.112.0
 	github.com/sirupsen/logrus v1.9.3
 	github.com/spf13/cobra v1.8.1
@@ -20,6 +23,7 @@ require (
 	github.com/VividCortex/ewma v1.2.0 // indirect
 	github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d // indirect
 	github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2 // indirect
+	github.com/cheggaaa/pb/v3 v3.1.6 // indirect
 	github.com/containerd/cgroups/v3 v3.0.3 // indirect
 	github.com/containerd/errdefs v0.1.0 // indirect
 	github.com/containerd/stargz-snapshotter/estargz v0.15.1 // indirect
@@ -37,6 +41,7 @@ require (
 	github.com/docker/docker-credential-helpers v0.8.2 // indirect
 	github.com/docker/go-connections v0.5.0 // indirect
 	github.com/docker/go-units v0.5.0 // indirect
+	github.com/fatih/color v1.18.0 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
 	github.com/go-jose/go-jose/v4 v4.0.2 // indirect
 	github.com/go-logr/logr v1.4.2 // indirect
@@ -68,6 +73,8 @@ require (
 	github.com/klauspost/pgzip v1.2.6 // indirect
 	github.com/letsencrypt/boulder v0.0.0-20240418210053-89b07f4543e0 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect
+	github.com/mattn/go-colorable v0.1.14 // indirect
+	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/mattn/go-runewidth v0.0.16 // indirect
 	github.com/mattn/go-sqlite3 v1.14.22 // indirect
 	github.com/miekg/pkcs11 v1.1.1 // indirect

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ toolchain go1.22.2
 require (
 	github.com/BurntSushi/toml v1.4.0
 	github.com/gobwas/glob v0.2.3
-	github.com/osbuild/bootc-image-builder/bib v0.0.0-20250125114430-c5d674173ba0
+	github.com/osbuild/bootc-image-builder/bib v0.0.0-20250128074618-f6403409fc97
 	github.com/osbuild/images v0.112.0
 	github.com/sirupsen/logrus v1.9.3
 	github.com/spf13/cobra v1.8.1

--- a/go.sum
+++ b/go.sum
@@ -25,6 +25,8 @@ github.com/cenkalti/backoff/v4 v4.2.1/go.mod h1:Y3VNntkOUPxTVeUxJ/G5vcM//AlwfmyY
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
+github.com/cheggaaa/pb/v3 v3.1.6 h1:h0x+vd7EiUohAJ29DJtJy+SNAc55t/elW3jCD086EXk=
+github.com/cheggaaa/pb/v3 v3.1.6/go.mod h1:urxmfVtaxT+9aWk92DbsvXFZtNSWQSO5TRAp+MJ3l1s=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/containerd/cgroups/v3 v3.0.3 h1:S5ByHZ/h9PMe5IOQoN7E+nMc2UcLEM/V48DGDJ9kip0=
@@ -74,6 +76,8 @@ github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymF
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
+github.com/fatih/color v1.18.0 h1:S8gINlzdQ840/4pfAwic/ZE0djQEH3wM94VfqLTZcOM=
+github.com/fatih/color v1.18.0/go.mod h1:4FelSpRwEGDpQ12mAdzqdOukCy4u8WUtOY6lkT/6HfU=
 github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2Wg=
 github.com/felixge/httpsnoop v1.0.4/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/go-jose/go-jose/v4 v4.0.2 h1:R3l3kkBds16bO7ZFAEEcofK0MkrAJt3jlJznWZG0nvk=
@@ -175,6 +179,10 @@ github.com/letsencrypt/boulder v0.0.0-20240418210053-89b07f4543e0 h1:aiPrFdHDCCv
 github.com/letsencrypt/boulder v0.0.0-20240418210053-89b07f4543e0/go.mod h1:srVwm2N3DC/tWqQ+igZXDrmKlNRN8X/dmJ1wEZrv760=
 github.com/mailru/easyjson v0.7.7 h1:UGYAvKxe3sBsEDzO8ZeWOSlIQfWFlxbzLZe7hwFURr0=
 github.com/mailru/easyjson v0.7.7/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJJLY9Nlc=
+github.com/mattn/go-colorable v0.1.14 h1:9A9LHSqF/7dyVVX6g0U9cwm9pG3kP9gSzcuIPHPsaIE=
+github.com/mattn/go-colorable v0.1.14/go.mod h1:6LmQG8QLFO4G5z1gPvYEzlUgJ2wF+stgPZH1UqBm1s8=
+github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
+github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/mattn/go-runewidth v0.0.16 h1:E5ScNMtiwvlvB5paMFdw9p4kSQzbXFikJ5SQO6TULQc=
 github.com/mattn/go-runewidth v0.0.16/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh153qUoGf23w=
 github.com/mattn/go-sqlite3 v1.14.22 h1:2gZY6PC6kBnID23Tichd1K+Z0oS6nE/XwU+Vz/5o4kU=
@@ -210,6 +218,8 @@ github.com/opencontainers/runtime-spec v1.2.0 h1:z97+pHb3uELt/yiAWD691HNHQIF07bE
 github.com/opencontainers/runtime-spec v1.2.0/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/C5hL+LL3ko9hs6T5lQ0=
 github.com/opencontainers/selinux v1.11.0 h1:+5Zbo97w3Lbmb3PeqQtpmTkMwsW5nRI3YaLpt7tQ7oU=
 github.com/opencontainers/selinux v1.11.0/go.mod h1:E5dMC3VPuVvVHDYmi78qvhJp8+M586T4DlDRYpFkyec=
+github.com/osbuild/bootc-image-builder/bib v0.0.0-20250125114430-c5d674173ba0 h1:aLxeLEO/C6/mAc4O8fgmDE7uaf6EwAiW79IP2GI/bvo=
+github.com/osbuild/bootc-image-builder/bib v0.0.0-20250125114430-c5d674173ba0/go.mod h1:22erXOiwfznPLNE5Y8hp35fnE0vh5ZjWp/iIQsVnYTg=
 github.com/osbuild/images v0.112.0 h1:+pKwPniwYTRRgist6V+7DQfZEg7osddl1z4pASecq4M=
 github.com/osbuild/images v0.112.0/go.mod h1:58tzp7jV50rjaH9gMpvmQdVati0c4TaC5Op7wmSD/tY=
 github.com/ostreedev/ostree-go v0.0.0-20210805093236-719684c64e4f h1:/UDgs8FGMqwnHagNDPGOlts35QkhAZ8by3DR7nMih7M=
@@ -349,6 +359,7 @@ golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5h
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.29.0 h1:TPYlXGxvx1MGTn2GiZDhnjPA9wZzZeGKHHmKhHYvgaU=
 golang.org/x/sys v0.29.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 golang.org/x/term v0.27.0 h1:WP60Sv1nlK1T6SupCHbXzSaN0b9wUmsPoRS9b61A23Q=

--- a/go.sum
+++ b/go.sum
@@ -220,6 +220,8 @@ github.com/opencontainers/selinux v1.11.0 h1:+5Zbo97w3Lbmb3PeqQtpmTkMwsW5nRI3YaL
 github.com/opencontainers/selinux v1.11.0/go.mod h1:E5dMC3VPuVvVHDYmi78qvhJp8+M586T4DlDRYpFkyec=
 github.com/osbuild/bootc-image-builder/bib v0.0.0-20250125114430-c5d674173ba0 h1:aLxeLEO/C6/mAc4O8fgmDE7uaf6EwAiW79IP2GI/bvo=
 github.com/osbuild/bootc-image-builder/bib v0.0.0-20250125114430-c5d674173ba0/go.mod h1:22erXOiwfznPLNE5Y8hp35fnE0vh5ZjWp/iIQsVnYTg=
+github.com/osbuild/bootc-image-builder/bib v0.0.0-20250128074618-f6403409fc97 h1:Xyv+vDEGCcG1qkHkdQFPBXhvM5WiMiAJm/AjBkzW4Sw=
+github.com/osbuild/bootc-image-builder/bib v0.0.0-20250128074618-f6403409fc97/go.mod h1:22erXOiwfznPLNE5Y8hp35fnE0vh5ZjWp/iIQsVnYTg=
 github.com/osbuild/images v0.112.0 h1:+pKwPniwYTRRgist6V+7DQfZEg7osddl1z4pASecq4M=
 github.com/osbuild/images v0.112.0/go.mod h1:58tzp7jV50rjaH9gMpvmQdVati0c4TaC5Op7wmSD/tY=
 github.com/ostreedev/ostree-go v0.0.0-20210805093236-719684c64e4f h1:/UDgs8FGMqwnHagNDPGOlts35QkhAZ8by3DR7nMih7M=

--- a/internal/testutil/testutil_test.go
+++ b/internal/testutil/testutil_test.go
@@ -1,6 +1,8 @@
 package testutil_test
 
 import (
+	"fmt"
+	"os"
 	"os/exec"
 	"testing"
 
@@ -22,4 +24,13 @@ func TestMockCommand(t *testing.T) {
 		{"run1-arg1", "run1-arg2"},
 		{"run2-arg1", "run2-arg2"},
 	}, fakeCmd.Calls())
+}
+
+func TestCaptureStdout(t *testing.T) {
+	stdout, stderr := testutil.CaptureStdio(t, func() {
+		fmt.Fprintf(os.Stdout, "output on stdout")
+		fmt.Fprintf(os.Stderr, "output on stderr")
+	})
+	assert.Equal(t, "output on stdout", stdout)
+	assert.Equal(t, "output on stderr", stderr)
 }

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,4 +1,5 @@
 import subprocess
+import textwrap
 
 import pytest
 
@@ -13,5 +14,41 @@ def build_container_fixture():
         "podman", "build",
         "-f", "Containerfile",
         "-t", container_tag,
+    ])
+    return container_tag
+
+
+# XXX: copied from bib
+@pytest.fixture(name="build_fake_container", scope="session")
+def build_fake_container_fixture(tmpdir_factory, build_container):
+    """Build a container with a fake osbuild and returns the name"""
+    tmp_path = tmpdir_factory.mktemp("build-fake-container")
+
+    fake_osbuild_path = tmp_path / "fake-osbuild"
+    fake_osbuild_path.write_text(textwrap.dedent("""\
+    #!/bin/bash -e
+
+    # injest generated manifest from the images library, if we do not
+    # do this images may fail with "broken" pipe errors
+    cat - >/dev/null
+
+    mkdir -p /output/qcow2
+    echo "fake-disk.qcow2" > /output/qcow2/disk.qcow2
+
+    """), encoding="utf8")
+
+    cntf_path = tmp_path / "Containerfile"
+
+    cntf_path.write_text(textwrap.dedent(f"""\n
+    FROM {build_container}
+    COPY fake-osbuild /usr/bin/osbuild
+    RUN chmod 755 /usr/bin/osbuild
+    """), encoding="utf8")
+
+    container_tag = "bootc-image-builder-test-faked-osbuild"
+    subprocess.check_call([
+        "podman", "build",
+        "-t", container_tag,
+        tmp_path,
     ])
     return container_tag

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -32,6 +32,7 @@ def build_fake_container_fixture(tmpdir_factory, build_container):
     # do this images may fail with "broken" pipe errors
     cat - >/dev/null
 
+    echo "osbuild-stdout-output"
     mkdir -p /output/qcow2
     echo "fake-disk.qcow2" > /output/qcow2/disk.qcow2
 


### PR DESCRIPTION
[draft as this lacks tests,  not easy to do right now without duplicating code from bib, looking into this]

This commit add progress reporting similar to what `bib` is doing.
It imports the progress from `bootc-image-builder` for now. There
is an open PR for moving this to images but there are some
concerns about moving it there so for now we just use bib.
This is not too bad because eventually bib and ibcli will merge.

