### PR TITLE
ci: enable aarch64 container builds

### DIFF
--- a/.github/workflows/container.yaml
+++ b/.github/workflows/container.yaml
@@ -16,6 +16,9 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
 
@@ -40,7 +43,7 @@ jobs:
         uses: docker/build-push-action@v4
         with:
           context: .
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64
           file: ./Containerfile
           push: ${{ github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/') }}
           cache-from: type=registry,ref=ghcr.io/osbuild/image-builder-cli:latest


### PR DESCRIPTION
The promised followup for #11. Also builds `aarch64` containers; note that this is slow hence it wasn't in the initial commit.