### PR TITLE
manifestgen: port to the new `images` manifest seed

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ go 1.21.0
 require (
 	github.com/BurntSushi/toml v1.4.0
 	github.com/gobwas/glob v0.2.3
-	github.com/osbuild/images v0.106.0
+	github.com/osbuild/images v0.108.0
 	github.com/sirupsen/logrus v1.9.3
 	github.com/spf13/cobra v1.8.1
 	github.com/stretchr/testify v1.10.0

--- a/go.sum
+++ b/go.sum
@@ -210,8 +210,8 @@ github.com/opencontainers/runtime-spec v1.2.0 h1:z97+pHb3uELt/yiAWD691HNHQIF07bE
 github.com/opencontainers/runtime-spec v1.2.0/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/C5hL+LL3ko9hs6T5lQ0=
 github.com/opencontainers/selinux v1.11.0 h1:+5Zbo97w3Lbmb3PeqQtpmTkMwsW5nRI3YaLpt7tQ7oU=
 github.com/opencontainers/selinux v1.11.0/go.mod h1:E5dMC3VPuVvVHDYmi78qvhJp8+M586T4DlDRYpFkyec=
-github.com/osbuild/images v0.106.0 h1:9vDLkSporWPNT4ltFy236/ONver5u7MqIgIutwECev0=
-github.com/osbuild/images v0.106.0/go.mod h1:4bNmMQOVadIKVC1q8zsLO8tdEQFH90zIp+MQBQUnCiE=
+github.com/osbuild/images v0.108.0 h1:I6Ol6KsbsvCfJnipKKuGnt4todY2NvNt742Bx7y+f+Y=
+github.com/osbuild/images v0.108.0/go.mod h1:4bNmMQOVadIKVC1q8zsLO8tdEQFH90zIp+MQBQUnCiE=
 github.com/ostreedev/ostree-go v0.0.0-20210805093236-719684c64e4f h1:/UDgs8FGMqwnHagNDPGOlts35QkhAZ8by3DR7nMih7M=
 github.com/ostreedev/ostree-go v0.0.0-20210805093236-719684c64e4f/go.mod h1:J6OG6YJVEWopen4avK3VNQSnALmmjvniMmni/YFYAwc=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=

--- a/internal/manifestgen/manifestgen.go
+++ b/internal/manifestgen/manifestgen.go
@@ -5,7 +5,6 @@ import (
 	"io"
 	"os"
 	"strings"
-	"time"
 
 	"github.com/osbuild/images/pkg/blueprint"
 	"github.com/osbuild/images/pkg/container"
@@ -152,17 +151,12 @@ func (mg *Generator) Generate(bp *blueprint.Blueprint, dist distro.Distro, imgTy
 	if imgOpts == nil {
 		imgOpts = &distro.ImageOptions{}
 	}
-	// we may allow to customize the seed in the future via imgOpts or
-	// an environment variable
-	// XXX: look into "images" so that it automatically seeds when pasing
-	// a "0" seed.
-	seed := time.Now().UnixNano()
 
 	repos, err := mg.reporegistry.ReposByImageTypeName(dist.Name(), a.Name(), imgType.Name())
 	if err != nil {
 		return err
 	}
-	preManifest, warnings, err := imgType.Manifest(bp, *imgOpts, repos, seed)
+	preManifest, warnings, err := imgType.Manifest(bp, *imgOpts, repos, nil)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This moves to the new images Manifest() API from PR#1107.