### PR TITLE
manifestgen: pass missing repoConfig to preManifest.Serialize()

### DIFF
--- a/internal/manifestgen/manifestgen.go
+++ b/internal/manifestgen/manifestgen.go
@@ -165,7 +165,7 @@ func (mg *Generator) Generate(bp *blueprint.Blueprint, dist distro.Distro, imgTy
 		// what are these warnings?
 		return fmt.Errorf("warnings during manifest creation: %v", strings.Join(warnings, "\n"))
 	}
-	packageSpecs, _, err := mg.depsolver(mg.cacheDir, preManifest.GetPackageSetChains(), dist, a.Name())
+	packageSpecs, repoConfig, err := mg.depsolver(mg.cacheDir, preManifest.GetPackageSetChains(), dist, a.Name())
 	if err != nil {
 		return err
 	}
@@ -177,7 +177,7 @@ func (mg *Generator) Generate(bp *blueprint.Blueprint, dist distro.Distro, imgTy
 	if err != nil {
 		return err
 	}
-	mf, err := preManifest.Serialize(packageSpecs, containerSpecs, commitSpecs, nil)
+	mf, err := preManifest.Serialize(packageSpecs, containerSpecs, commitSpecs, repoConfig)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
When depsolve is run it returns a list of packageSpecs and the matching repository config. This repo config is different/distinct from the repository config that is passed into depsolve via the package sets or the repositories that are loaded via the reporegistry and needs to be passed into `manifest.Serialize()`.

The key different is that the depsovle `repoConfig` contains the repo.Id that match the packageSpec.RepoId. With those two matching IDs we can use librepo (see osbuild PR#1974) to infere what mirror to use for what package.

This commit now passes the correct repoConfig into preManifest.Serialize() now.

No test (sorry!) as this is really hard to test in isolation, there is nothing observable today from repoConfig and it is impossible to add a "witness" pipelien that could check that the right argument is passed in `pipeline.serializeStart()`. So until we refactor images you will have to take my word for this (sorry again).

Alternatively we could only merge once librepo is available, then the issue becomes apparent as nothing will work without this (i.e. there it will be tested implicitly)