### PR TITLE
main: add `--use-librepo` to support librepo  downloads

### DIFF
--- a/cmd/image-builder/main.go
+++ b/cmd/image-builder/main.go
@@ -199,7 +199,7 @@ operating sytsems like centos and RHEL with easy customizations support.`,
 	manifestCmd.Flags().String("ostree-ref", "", `OSTREE reference`)
 	manifestCmd.Flags().String("ostree-parent", "", `OSTREE parent`)
 	manifestCmd.Flags().String("ostree-url", "", `OSTREE url`)
-	manifestCmd.Flags().Bool("use-librepo", false, `(experimental) use librepo to download packages, needs new osbuild`)
+	manifestCmd.Flags().Bool("use-librepo", true, `use librepo to download packages (disable if you use old versions of osbuild)`)
 	rootCmd.AddCommand(manifestCmd)
 
 	buildCmd := &cobra.Command{

--- a/cmd/image-builder/main.go
+++ b/cmd/image-builder/main.go
@@ -110,18 +110,23 @@ func cmdManifestWrapper(cmd *cobra.Command, args []string, w io.Writer, archChec
 		return nil, err
 	}
 
-	res, err := getOneImage(dataDir, distroStr, imgTypeStr, archStr)
+	img, err := getOneImage(dataDir, distroStr, imgTypeStr, archStr)
 	if err != nil {
 		return nil, err
 	}
 	if archChecker != nil {
-		if err := archChecker(res.Arch.Name()); err != nil {
+		if err := archChecker(img.Arch.Name()); err != nil {
 			return nil, err
 		}
 	}
 
-	err = generateManifest(dataDir, blueprintPath, res, w, ostreeImgOpts, rpmDownloader)
-	return res, err
+	opts := &manifestOptions{
+		BlueprintPath: blueprintPath,
+		Ostree:        ostreeImgOpts,
+		RpmDownloader: rpmDownloader,
+	}
+	err = generateManifest(dataDir, img, w, opts)
+	return img, err
 }
 
 func cmdManifest(cmd *cobra.Command, args []string) error {

--- a/cmd/image-builder/main.go
+++ b/cmd/image-builder/main.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/osbuild/images/pkg/arch"
 	"github.com/osbuild/images/pkg/imagefilter"
+	"github.com/osbuild/images/pkg/osbuild"
 	"github.com/osbuild/images/pkg/ostree"
 
 	"github.com/osbuild/image-builder-cli/internal/blueprintload"
@@ -83,6 +84,14 @@ func cmdManifestWrapper(cmd *cobra.Command, args []string, w io.Writer, archChec
 	if err != nil {
 		return nil, err
 	}
+	useLibrepo, err := cmd.Flags().GetBool("use-librepo")
+	if err != nil {
+		return nil, err
+	}
+	var rpmDownloader osbuild.RpmDownloader
+	if useLibrepo {
+		rpmDownloader = osbuild.RpmDownloaderLibrepo
+	}
 
 	blueprintPath, err := cmd.Flags().GetString("blueprint")
 	if err != nil {
@@ -111,7 +120,7 @@ func cmdManifestWrapper(cmd *cobra.Command, args []string, w io.Writer, archChec
 		}
 	}
 
-	err = generateManifest(dataDir, blueprintPath, res, w, ostreeImgOpts)
+	err = generateManifest(dataDir, blueprintPath, res, w, ostreeImgOpts, rpmDownloader)
 	return res, err
 }
 
@@ -185,6 +194,7 @@ operating sytsems like centos and RHEL with easy customizations support.`,
 	manifestCmd.Flags().String("ostree-ref", "", `OSTREE reference`)
 	manifestCmd.Flags().String("ostree-parent", "", `OSTREE parent`)
 	manifestCmd.Flags().String("ostree-url", "", `OSTREE url`)
+	manifestCmd.Flags().Bool("use-librepo", false, `(experimental) use librepo to download packages, needs new osbuild`)
 	rootCmd.AddCommand(manifestCmd)
 
 	buildCmd := &cobra.Command{

--- a/cmd/image-builder/main_test.go
+++ b/cmd/image-builder/main_test.go
@@ -162,29 +162,36 @@ func TestManifestIntegrationSmoke(t *testing.T) {
 	restore := main.MockNewRepoRegistry(testrepos.New)
 	defer restore()
 
-	restore = main.MockOsArgs([]string{
-		"manifest",
-		"qcow2",
-		"--arch=x86_64",
-		"--distro=centos-9",
-		fmt.Sprintf("--blueprint=%s", makeTestBlueprint(t, testBlueprint)),
-	})
-	defer restore()
+	for _, useLibrepo := range []bool{false, true} {
+		t.Run(fmt.Sprintf("use-librepo: %v", useLibrepo), func(t *testing.T) {
+			restore = main.MockOsArgs([]string{
+				"manifest",
+				"qcow2",
+				"--arch=x86_64",
+				"--distro=centos-9",
+				fmt.Sprintf("--blueprint=%s", makeTestBlueprint(t, testBlueprint)),
+				fmt.Sprintf("--use-librepo=%v", useLibrepo),
+			})
+			defer restore()
 
-	var fakeStdout bytes.Buffer
-	restore = main.MockOsStdout(&fakeStdout)
-	defer restore()
+			var fakeStdout bytes.Buffer
+			restore = main.MockOsStdout(&fakeStdout)
+			defer restore()
 
-	err := main.Run()
-	assert.NoError(t, err)
+			err := main.Run()
+			assert.NoError(t, err)
 
-	pipelineNames, err := manifesttest.PipelineNamesFrom(fakeStdout.Bytes())
-	assert.NoError(t, err)
-	assert.Contains(t, pipelineNames, "qcow2")
+			pipelineNames, err := manifesttest.PipelineNamesFrom(fakeStdout.Bytes())
+			assert.NoError(t, err)
+			assert.Contains(t, pipelineNames, "qcow2")
 
-	// XXX: provide helpers in manifesttest to extract this in a nicer way
-	assert.Contains(t, fakeStdout.String(), `{"type":"org.osbuild.users","options":{"users":{"alice":{}}}}`)
-	assert.Contains(t, fakeStdout.String(), `"image":{"name":"registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"`)
+			// XXX: provide helpers in manifesttest to extract this in a nicer way
+			assert.Contains(t, fakeStdout.String(), `{"type":"org.osbuild.users","options":{"users":{"alice":{}}}}`)
+			assert.Contains(t, fakeStdout.String(), `"image":{"name":"registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"`)
+
+			assert.Equal(t, strings.Contains(fakeStdout.String(), "org.osbuild.librepo"), useLibrepo)
+		})
+	}
 }
 
 func TestManifestIntegrationCrossArch(t *testing.T) {

--- a/cmd/image-builder/manifest.go
+++ b/cmd/image-builder/manifest.go
@@ -5,20 +5,22 @@ import (
 
 	"github.com/osbuild/images/pkg/distro"
 	"github.com/osbuild/images/pkg/imagefilter"
+	"github.com/osbuild/images/pkg/osbuild"
 	"github.com/osbuild/images/pkg/ostree"
 
 	"github.com/osbuild/image-builder-cli/internal/blueprintload"
 	"github.com/osbuild/image-builder-cli/internal/manifestgen"
 )
 
-func generateManifest(dataDir, blueprintPath string, res *imagefilter.Result, output io.Writer, ostreeOpts *ostree.ImageOptions) error {
+func generateManifest(dataDir, blueprintPath string, res *imagefilter.Result, output io.Writer, ostreeOpts *ostree.ImageOptions, rpmDownloader osbuild.RpmDownloader) error {
 	repos, err := newRepoRegistry(dataDir)
 	if err != nil {
 		return err
 	}
 	// XXX: add --rpmmd/cachedir option like bib
 	mg, err := manifestgen.New(repos, &manifestgen.Options{
-		Output: output,
+		Output:        output,
+		RpmDownloader: rpmDownloader,
 	})
 	if err != nil {
 		return err

--- a/cmd/image-builder/manifest.go
+++ b/cmd/image-builder/manifest.go
@@ -12,7 +12,13 @@ import (
 	"github.com/osbuild/image-builder-cli/internal/manifestgen"
 )
 
-func generateManifest(dataDir, blueprintPath string, res *imagefilter.Result, output io.Writer, ostreeOpts *ostree.ImageOptions, rpmDownloader osbuild.RpmDownloader) error {
+type manifestOptions struct {
+	BlueprintPath string
+	Ostree        *ostree.ImageOptions
+	RpmDownloader osbuild.RpmDownloader
+}
+
+func generateManifest(dataDir string, img *imagefilter.Result, output io.Writer, opts *manifestOptions) error {
 	repos, err := newRepoRegistry(dataDir)
 	if err != nil {
 		return err
@@ -20,21 +26,21 @@ func generateManifest(dataDir, blueprintPath string, res *imagefilter.Result, ou
 	// XXX: add --rpmmd/cachedir option like bib
 	mg, err := manifestgen.New(repos, &manifestgen.Options{
 		Output:        output,
-		RpmDownloader: rpmDownloader,
+		RpmDownloader: opts.RpmDownloader,
 	})
 	if err != nil {
 		return err
 	}
-	bp, err := blueprintload.Load(blueprintPath)
+	bp, err := blueprintload.Load(opts.BlueprintPath)
 	if err != nil {
 		return err
 	}
 	var imgOpts *distro.ImageOptions
-	if ostreeOpts != nil {
+	if opts.Ostree != nil {
 		imgOpts = &distro.ImageOptions{
-			OSTree: ostreeOpts,
+			OSTree: opts.Ostree,
 		}
 	}
 
-	return mg.Generate(bp, res.Distro, res.ImgType, res.Arch, imgOpts)
+	return mg.Generate(bp, img.Distro, img.ImgType, img.Arch, imgOpts)
 }

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ go 1.21.0
 require (
 	github.com/BurntSushi/toml v1.4.0
 	github.com/gobwas/glob v0.2.3
-	github.com/osbuild/images v0.108.1-0.20250109111809-f295ad7807a3
+	github.com/osbuild/images v0.109.1-0.20250117082457-97ca7c62eb09
 	github.com/sirupsen/logrus v1.9.3
 	github.com/spf13/cobra v1.8.1
 	github.com/stretchr/testify v1.10.0

--- a/go.sum
+++ b/go.sum
@@ -210,8 +210,8 @@ github.com/opencontainers/runtime-spec v1.2.0 h1:z97+pHb3uELt/yiAWD691HNHQIF07bE
 github.com/opencontainers/runtime-spec v1.2.0/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/C5hL+LL3ko9hs6T5lQ0=
 github.com/opencontainers/selinux v1.11.0 h1:+5Zbo97w3Lbmb3PeqQtpmTkMwsW5nRI3YaLpt7tQ7oU=
 github.com/opencontainers/selinux v1.11.0/go.mod h1:E5dMC3VPuVvVHDYmi78qvhJp8+M586T4DlDRYpFkyec=
-github.com/osbuild/images v0.108.1-0.20250109111809-f295ad7807a3 h1:gUuQvYWQggIrR6/tIGOiFz4L1kapAPGL1xdJ9SqvkQs=
-github.com/osbuild/images v0.108.1-0.20250109111809-f295ad7807a3/go.mod h1:58tzp7jV50rjaH9gMpvmQdVati0c4TaC5Op7wmSD/tY=
+github.com/osbuild/images v0.109.1-0.20250117082457-97ca7c62eb09 h1:9ABt4zMJ6tNp1+AHI4FrDq1Fxy/l5uYuDXs6EOR6QJ0=
+github.com/osbuild/images v0.109.1-0.20250117082457-97ca7c62eb09/go.mod h1:58tzp7jV50rjaH9gMpvmQdVati0c4TaC5Op7wmSD/tY=
 github.com/ostreedev/ostree-go v0.0.0-20210805093236-719684c64e4f h1:/UDgs8FGMqwnHagNDPGOlts35QkhAZ8by3DR7nMih7M=
 github.com/ostreedev/ostree-go v0.0.0-20210805093236-719684c64e4f/go.mod h1:J6OG6YJVEWopen4avK3VNQSnALmmjvniMmni/YFYAwc=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=

--- a/image-builder-cli.spec
+++ b/image-builder-cli.spec
@@ -3,8 +3,12 @@
 %bcond_with tests
 %bcond_with relax_requires
 
-# The minimum required osbuild version
-%global min_osbuild_version 129
+# The minimum required osbuild version, note that this used to be 129
+# but got bumped to 138 for librepo support which is not strictly
+# required. So if this needs backport to places where there is no
+# recent osbuild available we could simply make --use-librepo false
+# and go back to 129.
+%global min_osbuild_version 138
 
 %global goipath         github.com/osbuild/image-builder-cli
 

--- a/internal/manifestgen/manifestgen.go
+++ b/internal/manifestgen/manifestgen.go
@@ -10,6 +10,7 @@ import (
 	"github.com/osbuild/images/pkg/container"
 	"github.com/osbuild/images/pkg/distro"
 	"github.com/osbuild/images/pkg/dnfjson"
+	"github.com/osbuild/images/pkg/osbuild"
 	"github.com/osbuild/images/pkg/ostree"
 	"github.com/osbuild/images/pkg/reporegistry"
 	"github.com/osbuild/images/pkg/rpmmd"
@@ -100,6 +101,8 @@ type Options struct {
 	Depsolver         DepsolveFunc
 	ContainerResolver ContainerResolverFunc
 	CommitResolver    CommitResolverFunc
+
+	RpmDownloader osbuild.RpmDownloader
 }
 
 // Generator can generate an osbuild manifest from a given repository
@@ -113,6 +116,8 @@ type Generator struct {
 	commitResolver    CommitResolverFunc
 
 	reporegistry *reporegistry.RepoRegistry
+
+	rpmDownloader osbuild.RpmDownloader
 }
 
 // New will create a new manifest generator
@@ -128,6 +133,7 @@ func New(reporegistry *reporegistry.RepoRegistry, opts *Options) (*Generator, er
 		depsolver:         opts.Depsolver,
 		containerResolver: opts.ContainerResolver,
 		commitResolver:    opts.CommitResolver,
+		rpmDownloader:     opts.RpmDownloader,
 	}
 	if mg.out == nil {
 		mg.out = os.Stdout
@@ -177,7 +183,7 @@ func (mg *Generator) Generate(bp *blueprint.Blueprint, dist distro.Distro, imgTy
 	if err != nil {
 		return err
 	}
-	mf, err := preManifest.Serialize(packageSpecs, containerSpecs, commitSpecs, repoConfig)
+	mf, err := preManifest.Serialize(packageSpecs, containerSpecs, commitSpecs, repoConfig, mg.rpmDownloader)
 	if err != nil {
 		return err
 	}

--- a/internal/manifestgen/manifestgen_test.go
+++ b/internal/manifestgen/manifestgen_test.go
@@ -4,16 +4,19 @@ import (
 	"bytes"
 	"crypto/sha256"
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/osbuild/images/pkg/blueprint"
 	"github.com/osbuild/images/pkg/container"
 	"github.com/osbuild/images/pkg/distro"
 	"github.com/osbuild/images/pkg/distrofactory"
 	"github.com/osbuild/images/pkg/imagefilter"
+	"github.com/osbuild/images/pkg/osbuild"
 	"github.com/osbuild/images/pkg/ostree"
 	"github.com/osbuild/images/pkg/rpmmd"
 	testrepos "github.com/osbuild/images/test/data/repositories"
@@ -45,30 +48,43 @@ func TestManifestGeneratorDepsolve(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, 1, len(res))
 
-	var osbuildManifest bytes.Buffer
-	opts := &manifestgen.Options{
-		Output:            &osbuildManifest,
-		Depsolver:         fakeDepsolve,
-		CommitResolver:    panicCommitResolver,
-		ContainerResolver: panicContainerResolver,
+	for _, useLibrepo := range []bool{false, true} {
+		t.Run(fmt.Sprintf("useLibrepo: %v", useLibrepo), func(t *testing.T) {
+			var rpmDownloader osbuild.RpmDownloader
+			if useLibrepo {
+				rpmDownloader = osbuild.RpmDownloaderLibrepo
+			}
+
+			var osbuildManifest bytes.Buffer
+			opts := &manifestgen.Options{
+				Output:            &osbuildManifest,
+				Depsolver:         fakeDepsolve,
+				CommitResolver:    panicCommitResolver,
+				ContainerResolver: panicContainerResolver,
+
+				RpmDownloader: rpmDownloader,
+			}
+			mg, err := manifestgen.New(repos, opts)
+			assert.NoError(t, err)
+			assert.NotNil(t, mg)
+			var bp blueprint.Blueprint
+			err = mg.Generate(&bp, res[0].Distro, res[0].ImgType, res[0].Arch, nil)
+			require.NoError(t, err)
+
+			pipelineNames, err := manifesttest.PipelineNamesFrom(osbuildManifest.Bytes())
+			assert.NoError(t, err)
+			assert.Equal(t, []string{"build", "os", "image", "qcow2"}, pipelineNames)
+
+			// we expect at least a "kernel" package in the manifest,
+			// sadly the test distro does not really generate much here so we
+			// need to use this as a canary that resolving happend
+			// XXX: add testhelper to manifesttest for this
+			expectedSha256 := sha256For("kernel")
+			assert.Contains(t, osbuildManifest.String(), expectedSha256)
+
+			assert.Equal(t, strings.Contains(osbuildManifest.String(), "org.osbuild.librepo"), useLibrepo)
+		})
 	}
-	mg, err := manifestgen.New(repos, opts)
-	assert.NoError(t, err)
-	assert.NotNil(t, mg)
-	var bp blueprint.Blueprint
-	err = mg.Generate(&bp, res[0].Distro, res[0].ImgType, res[0].Arch, nil)
-	assert.NoError(t, err)
-
-	pipelineNames, err := manifesttest.PipelineNamesFrom(osbuildManifest.Bytes())
-	assert.NoError(t, err)
-	assert.Equal(t, []string{"build", "os", "image", "qcow2"}, pipelineNames)
-
-	// we expect at least a "kernel" package in the manifest,
-	// sadly the test distro does not really generate much here so we
-	// need to use this as a canary that resolving happend
-	// XXX: add testhelper to manifesttest for this
-	expectedSha256 := sha256For("kernel")
-	assert.Contains(t, osbuildManifest.String(), expectedSha256)
 }
 
 func TestManifestGeneratorWithOstreeCommit(t *testing.T) {
@@ -121,16 +137,25 @@ func fakeDepsolve(cacheDir string, packageSets map[string][]rpmmd.PackageSet, d 
 	depsolvedSets := make(map[string][]rpmmd.PackageSpec)
 	repoSets := make(map[string][]rpmmd.RepoConfig)
 	for name, pkgSets := range packageSets {
+		repoId := fmt.Sprintf("repo_id_%s", name)
 		var resolvedSet []rpmmd.PackageSpec
 		for _, pkgSet := range pkgSets {
 			for _, pkgName := range pkgSet.Include {
 				resolvedSet = append(resolvedSet, rpmmd.PackageSpec{
 					Name:     pkgName,
 					Checksum: sha256For(pkgName),
+					Path:     fmt.Sprintf("path/%s.rpm", pkgName),
+					RepoID:   repoId,
 				})
 			}
 		}
 		depsolvedSets[name] = resolvedSet
+		repoSets[name] = []rpmmd.RepoConfig{
+			{
+				Id:       repoId,
+				Metalink: "http://example.com/metalink",
+			},
+		}
 	}
 	return depsolvedSets, repoSets, nil
 }

--- a/test/test_container.py
+++ b/test/test_container.py
@@ -4,8 +4,9 @@ import subprocess
 import pytest
 
 
+@pytest.mark.parametrize("use_librepo", [False, True])
 @pytest.mark.skipif(os.getuid() != 0, reason="needs root")
-def test_container_builds_image(tmp_path, build_container):
+def test_container_builds_image(tmp_path, build_container, use_librepo):
     output_dir = tmp_path / "output"
     output_dir.mkdir()
     subprocess.check_call([
@@ -15,7 +16,8 @@ def test_container_builds_image(tmp_path, build_container):
         build_container,
         "build",
         "minimal-raw",
-        "--distro", "centos-9"
+        "--distro", "centos-9",
+        f"--use-librepo={use_librepo}",
     ])
     arch = "x86_64"
     assert (output_dir / f"centos-9-minimal-raw-{arch}/xz/disk.raw.xz").exists()


### PR DESCRIPTION
With that it then adds a new `--use-librepo` switch that will
enable librepo based downloading so that people can use
the new backend.

It is on by default currently, the risk is that it got no real testing
with secrets (but there code is there and similar to what curl
is doing) but the upside is that it will help with the centos/fedora
cases as there the mirror retry feature is import important.
