### PR TITLE
Makefile: fix Packit version by using git tag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ GOLANGCI_COMPOSER_IMAGE=composer_golangci
 #         pre-fetched but evaluated at time of use.
 #
 
-VERSION := $(shell (cd "$(SRCDIR)" && grep "^Version:" image-builder-cli.spec | sed -n 's/^[^0-9]*\([1-9][0-9]*\(\.[1-9][0-9]*\)*\)/\1/p'))
+VERSION := $(shell ( git describe --tags --abbrev=0 2>/dev/null || echo v1 ) | sed 's|v||')
 COMMIT = $(shell (cd "$(SRCDIR)" && git rev-parse HEAD))
 PACKAGE_NAME_VERSION = image-builder-cli-$(VERSION)
 PACKAGE_NAME_COMMIT = image-builder-cli-$(COMMIT)


### PR DESCRIPTION
For releases this does not change anything, as the version in the spec file is the same as the git tag. For
intermediate/tainted versions packer seems to patch the spec file to the version given in `.packit.yaml`
(which is the latest git-tag), then the filename and version would be inconsistent.

Rationale for this change was, that the packit build failed, as the version was set "4" but the source-tar-ball version was "5" from the spec file.