### PR TITLE
Makefile/packit: Set version to "single number" only for releases

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -16,7 +16,7 @@ srpm_build_deps:
 
 actions:
   # v1 just the default prior to having tags
-  get-current-version: bash -c "( git describe --tags --abbrev=0 2>/dev/null || echo v1 ) | sed 's|v||'"
+  get-current-version: bash -c "make show-version"
   post-upstream-clone: bash -c "go mod vendor && ./tools/rpm_spec_add_provides_bundle.sh"
   create-archive: bash -c "make release_artifacts"
 

--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ GOLANGCI_COMPOSER_IMAGE=composer_golangci
 #         pre-fetched but evaluated at time of use.
 #
 
-VERSION := $(shell ( git describe --tags --abbrev=0 2>/dev/null || echo v1 ) | sed 's|v||')
+VERSION := $(shell ( git describe --tags 2>/dev/null || echo v1 ) | sed -e 's|v||' -e 's/-/./g')
 COMMIT = $(shell (cd "$(SRCDIR)" && git rev-parse HEAD))
 PACKAGE_NAME_VERSION = image-builder-cli-$(VERSION)
 PACKAGE_NAME_COMMIT = image-builder-cli-$(COMMIT)
@@ -189,3 +189,6 @@ release_artifacts: $(RPM_TARBALL_VERSIONED)
 
 lint:
 	pre-commit run --all
+
+show-version:  ## Show the generated version to be reused in tools like `.packit.yaml`
+	@echo "$(VERSION)"


### PR DESCRIPTION
RPMs and releases should reflect if it's built from a release tag or some other commit.

Expected behavior is, that if you build a tag like "v4" the result is `image-builder-cli-4.tar.gz` otherwise it should visualize that this is NOT a release e.g. `image-builder-cli-4.12.g30166b0.tar.gz`