### PR TITLE
`--blueprint` (HMS-5340)

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ the full blueprint reference.
 
 Then just pass them as an additional argument after the image type:
 ```console
-$ sudo image-builder build qcow2 ./config.toml --distro centos-9
+$ sudo image-builder build qcow2 --blueprint ./config.toml --distro centos-9
 ...
 ```
 

--- a/cmd/image-builder/main.go
+++ b/cmd/image-builder/main.go
@@ -84,15 +84,18 @@ func cmdManifestWrapper(cmd *cobra.Command, args []string, w io.Writer, archChec
 		return nil, err
 	}
 
-	var blueprintPath string
-	imgTypeStr := args[0]
-	if len(args) > 1 {
-		blueprintPath = args[1]
+	blueprintPath, err := cmd.Flags().GetString("blueprint")
+	if err != nil {
+		return nil, err
 	}
+
+	imgTypeStr := args[0]
+
 	bp, err := blueprintload.Load(blueprintPath)
 	if err != nil {
 		return nil, err
 	}
+
 	distroStr, err = findDistro(distroStr, bp.Distro)
 	if err != nil {
 		return nil, err
@@ -176,6 +179,7 @@ operating sytsems like centos and RHEL with easy customizations support.`,
 		Args:         cobra.RangeArgs(1, 2),
 		Hidden:       true,
 	}
+	manifestCmd.Flags().String("blueprint", "", `blueprint to customize an image`)
 	manifestCmd.Flags().String("arch", "", `build manifest for a different architecture`)
 	manifestCmd.Flags().String("distro", "", `build manifest for a different distroname (e.g. centos-9)`)
 	manifestCmd.Flags().String("ostree-ref", "", `OSTREE reference`)

--- a/cmd/image-builder/main_test.go
+++ b/cmd/image-builder/main_test.go
@@ -3,6 +3,7 @@ package main_test
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"os"
@@ -166,7 +167,7 @@ func TestManifestIntegrationSmoke(t *testing.T) {
 		"qcow2",
 		"--arch=x86_64",
 		"--distro=centos-9",
-		makeTestBlueprint(t, testBlueprint),
+		fmt.Sprintf("--blueprint=%s", makeTestBlueprint(t, testBlueprint)),
 	})
 	defer restore()
 
@@ -318,7 +319,7 @@ func TestBuildIntegrationHappy(t *testing.T) {
 	restore = main.MockOsArgs([]string{
 		"build",
 		"qcow2",
-		makeTestBlueprint(t, testBlueprint),
+		fmt.Sprintf("--blueprint=%s", makeTestBlueprint(t, testBlueprint)),
 		"--distro", "centos-9",
 		"--store", tmpdir,
 	})


### PR DESCRIPTION
Changes the blueprint argument to a named argument after some discussion outside of GitHub. This allows for passing multiple image types later on and slightly simplifies the case of not passing a blueprint.

See #31.

/jira-epic COMPOSER-2418

JIRA: [HMS-5340](https://issues.redhat.com/browse/HMS-5340)