### PR TITLE
spellcheck: ignore release_artifacts directory

### DIFF
--- a/.spellcheck.yml
+++ b/.spellcheck.yml
@@ -8,7 +8,7 @@ matrix:
       camel-case: true
       mode: markdown
     sources:
-      - "**/*.md|!venv/**|!vendor/**"
+      - "**/*.md|!venv/**|!vendor/**|!release_artifacts/**"
     dictionary:
       wordlists:
         - .spellcheck-en-custom.txt


### PR DESCRIPTION
Pyspelling does not seem to read `.gitignore` file, so we'll manually exclude it for now.

fixes #62 