### PR TITLE
ibcli: add new --extra-artifacts option that can write an sbom file

### DIFF
--- a/.spellcheck-en-custom.txt
+++ b/.spellcheck-en-custom.txt
@@ -14,4 +14,7 @@ qcow
 UEFI
 datadir
 copr
+SBOM
+SBOMs
+spdx
 toml

--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ $ sudo dnf install osbuild osbuild-depsolve-dnf
 
 ## Examples
 
+### Listing
+
 To see the list of buildable images run:
 ```console
 $ image-builder list-images
@@ -52,6 +54,8 @@ rhel-10.0 type:ami arch:x86_64
 ...
 ```
 
+### Building
+
 To actually build an image run:
 ```console
 $ sudo image-builder build qcow2 --distro centos-9
@@ -59,6 +63,8 @@ $ sudo image-builder build qcow2 --distro centos-9
 ```
 this will create a directory `centos-9-qcow2-x86_64` under which the
 output is stored.
+
+### Blueprints
 
 Blueprints are supported, first create a `config.toml` and put e.g.
 the following content in:
@@ -79,6 +85,14 @@ Then just pass them as an additional argument after the image type:
 $ sudo image-builder build qcow2 --blueprint ./config.toml --distro centos-9
 ...
 ```
+
+### SBOMs
+
+It is possible to generate spdx based SBOM (software bill of materials)
+documents as part of the build. Just pass `--extra-artifacts=sbom` and
+it will put them into the output directory.
+
+### Filtering
 
 When listing images, it is possible to filter:
 ```console
@@ -104,6 +118,8 @@ The following filters are currently supported, shell-style globbing is supported
  * arch: the architecture name (e.g. x86_64)
  * type: the image type name (e.g. qcow2)
  * bootmode: the bootmode (legacy, UEFI, hybrid)
+
+### Output control
 
 The output can also be switched, supported are "text", "json":
 ```console

--- a/cmd/image-builder/build.go
+++ b/cmd/image-builder/build.go
@@ -1,9 +1,6 @@
 package main
 
 import (
-	"fmt"
-	"path/filepath"
-
 	"github.com/osbuild/images/pkg/imagefilter"
 	"github.com/osbuild/images/pkg/osbuild"
 )
@@ -12,9 +9,7 @@ func buildImage(res *imagefilter.Result, osbuildManifest []byte, osbuildStoreDir
 	// XXX: support output dir via commandline
 	// XXX2: support output filename via commandline (c.f.
 	//   https://github.com/osbuild/images/pull/1039)
-	outputDir := "."
-	buildName := fmt.Sprintf("%s-%s-%s", res.Distro.Name(), res.ImgType.Name(), res.Arch.Name())
-	jobOutputDir := filepath.Join(outputDir, buildName)
+	jobOutputDir := outputDirFor(res)
 
 	// XXX: support stremaing via images/pkg/osbuild/monitor.go
 	_, err := osbuild.RunOSBuild(osbuildManifest, osbuildStoreDir, jobOutputDir, res.ImgType.Exports(), nil, nil, false, osStderr)

--- a/cmd/image-builder/build.go
+++ b/cmd/image-builder/build.go
@@ -5,14 +5,15 @@ import (
 	"github.com/osbuild/images/pkg/osbuild"
 )
 
-func buildImage(res *imagefilter.Result, osbuildManifest []byte, osbuildStoreDir string) error {
-	// XXX: support output dir via commandline
-	// XXX2: support output filename via commandline (c.f.
+func buildImage(res *imagefilter.Result, osbuildManifest []byte, osbuildStoreDir, outputDir string) error {
+	// XXX: support output filename via commandline (c.f.
 	//   https://github.com/osbuild/images/pull/1039)
-	jobOutputDir := outputDirFor(res)
+	if outputDir == "" {
+		outputDir = outputDirFor(res)
+	}
 
 	// XXX: support stremaing via images/pkg/osbuild/monitor.go
-	_, err := osbuild.RunOSBuild(osbuildManifest, osbuildStoreDir, jobOutputDir, res.ImgType.Exports(), nil, nil, false, osStderr)
+	_, err := osbuild.RunOSBuild(osbuildManifest, osbuildStoreDir, outputDir, res.ImgType.Exports(), nil, nil, false, osStderr)
 	return err
 
 }

--- a/cmd/image-builder/main.go
+++ b/cmd/image-builder/main.go
@@ -89,6 +89,10 @@ func cmdManifestWrapper(cmd *cobra.Command, args []string, w io.Writer, archChec
 	if err != nil {
 		return nil, err
 	}
+	outputDir, err := cmd.Flags().GetString("output-dir")
+	if err != nil {
+		return nil, err
+	}
 	ostreeImgOpts, err := ostreeImageOptions(cmd)
 	if err != nil {
 		return nil, err
@@ -130,6 +134,7 @@ func cmdManifestWrapper(cmd *cobra.Command, args []string, w io.Writer, archChec
 	}
 
 	opts := &manifestOptions{
+		OutputDir:      outputDir,
 		BlueprintPath:  blueprintPath,
 		Ostree:         ostreeImgOpts,
 		RpmDownloader:  rpmDownloader,
@@ -149,6 +154,10 @@ func cmdBuild(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
+	outputDir, err := cmd.Flags().GetString("output-dir")
+	if err != nil {
+		return err
+	}
 
 	var mf bytes.Buffer
 	// XXX: check env here, i.e. if user is root and osbuild is installed
@@ -162,7 +171,7 @@ func cmdBuild(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	return buildImage(res, mf.Bytes(), storeDir)
+	return buildImage(res, mf.Bytes(), storeDir, outputDir)
 }
 
 func run() error {
@@ -181,6 +190,7 @@ operating sytsems like centos and RHEL with easy customizations support.`,
 		SilenceErrors: true,
 	}
 	rootCmd.PersistentFlags().String("datadir", "", `Override the default data direcotry for e.g. custom repositories/*.json data`)
+	rootCmd.PersistentFlags().String("output-dir", "", `Put output into the specified direcotry`)
 	rootCmd.PersistentFlags().StringArray("extra-artifacts", nil, `Export extra artifacts to the output dir (e.g. "sbom")`)
 	rootCmd.SetOut(osStdout)
 	rootCmd.SetErr(osStderr)

--- a/cmd/image-builder/main_test.go
+++ b/cmd/image-builder/main_test.go
@@ -379,7 +379,6 @@ func TestBuildIntegrationErrors(t *testing.T) {
 	restore = main.MockOsArgs([]string{
 		"build",
 		"qcow2",
-		makeTestBlueprint(t, testBlueprint),
 		"--distro", "centos-9",
 	})
 	defer restore()

--- a/cmd/image-builder/manifest.go
+++ b/cmd/image-builder/manifest.go
@@ -16,6 +16,7 @@ import (
 )
 
 type manifestOptions struct {
+	OutputDir      string
 	BlueprintPath  string
 	Ostree         *ostree.ImageOptions
 	RpmDownloader  osbuild.RpmDownloader
@@ -46,7 +47,10 @@ func generateManifest(dataDir string, img *imagefilter.Result, output io.Writer,
 		RpmDownloader: opts.RpmDownloader,
 	}
 	if slices.Contains(opts.ExtraArtifacts, "sbom") {
-		outputDir := outputDirFor(img)
+		outputDir := opts.OutputDir
+		if outputDir == "" {
+			outputDir = outputDirFor(img)
+		}
 		if err := os.MkdirAll(outputDir, 0755); err != nil {
 			return err
 		}

--- a/internal/manifestgen/manifestgen.go
+++ b/internal/manifestgen/manifestgen.go
@@ -1,9 +1,12 @@
 package manifestgen
 
 import (
+	"bytes"
+	"encoding/json"
 	"fmt"
 	"io"
 	"os"
+	"slices"
 	"strings"
 
 	"github.com/osbuild/images/pkg/blueprint"
@@ -35,7 +38,9 @@ func defaultDepsolver(cacheDir string, packageSets map[string][]rpmmd.PackageSet
 	solver := dnfjson.NewSolver(d.ModulePlatformID(), d.Releasever(), arch, d.Name(), cacheDir)
 	depsolvedSets := make(map[string]dnfjson.DepsolveResult)
 	for name, pkgSet := range packageSets {
-		res, err := solver.Depsolve(pkgSet, sbom.StandardTypeNone)
+		// XXX: is there harm in always generating an sbom?
+		// (expect for slightly longer runtime?)
+		res, err := solver.Depsolve(pkgSet, sbom.StandardTypeSpdx)
 		if err != nil {
 			return nil, fmt.Errorf("error depsolving: %w", err)
 		}
@@ -88,18 +93,31 @@ type (
 	ContainerResolverFunc func(containerSources map[string][]container.SourceSpec, archName string) (map[string][]container.Spec, error)
 
 	CommitResolverFunc func(commitSources map[string][]ostree.SourceSpec) (map[string][]ostree.CommitSpec, error)
+
+	SBOMWriterFunc func(filename string, content io.Reader) error
 )
 
 // Options contains the optional settings for the manifest generation.
 // For unset values defaults will be used.
 type Options struct {
-	Cachedir          string
-	Output            io.Writer
+	Cachedir string
+	Output   io.Writer
+
+	// There are two types of sbom outputs, one for the "payload"
+	// and one for the "buildroot", we allow exporting both here
+	SbomImageOutput     io.Writer
+	SbomBuildrootOutput io.Writer
+
 	Depsolver         DepsolveFunc
 	ContainerResolver ContainerResolverFunc
 	CommitResolver    CommitResolverFunc
 
 	RpmDownloader osbuild.RpmDownloader
+
+	// Will be called for each generated SBOM the filename
+	// contains the suggest filename string and the content
+	// can be read
+	SBOMWriter SBOMWriterFunc
 }
 
 // Generator can generate an osbuild manifest from a given repository
@@ -111,6 +129,7 @@ type Generator struct {
 	depsolver         DepsolveFunc
 	containerResolver ContainerResolverFunc
 	commitResolver    CommitResolverFunc
+	sbomWriter        SBOMWriterFunc
 
 	reporegistry *reporegistry.RepoRegistry
 
@@ -131,6 +150,7 @@ func New(reporegistry *reporegistry.RepoRegistry, opts *Options) (*Generator, er
 		containerResolver: opts.ContainerResolver,
 		commitResolver:    opts.CommitResolver,
 		rpmDownloader:     opts.RpmDownloader,
+		sbomWriter:        opts.SBOMWriter,
 	}
 	if mg.out == nil {
 		mg.out = os.Stdout
@@ -189,6 +209,33 @@ func (mg *Generator) Generate(bp *blueprint.Blueprint, dist distro.Distro, imgTy
 		return err
 	}
 	fmt.Fprintf(mg.out, "%s\n", mf)
+
+	if mg.sbomWriter != nil {
+		// XXX: this is very similar to
+		// osbuild-composer:jobimpl-osbuild.go, see if code
+		// can be shared
+		for plName, depsolvedPipeline := range depsolved {
+			pipelinePurpose := "unknown"
+			switch {
+			case slices.Contains(imgType.PayloadPipelines(), plName):
+				pipelinePurpose = "image"
+			case slices.Contains(imgType.BuildPipelines(), plName):
+				pipelinePurpose = "buildroot"
+			}
+			// XXX: sync with image-builder-cli:build.go name generation - can we have a shared helper?
+			imageName := fmt.Sprintf("%s-%s-%s", dist.Name(), imgType.Name(), a.Name())
+			sbomDocOutputFilename := fmt.Sprintf("%s.%s-%s.spdx.json", imageName, pipelinePurpose, plName)
+
+			var buf bytes.Buffer
+			enc := json.NewEncoder(&buf)
+			if err := enc.Encode(depsolvedPipeline.SBOM); err != nil {
+				return err
+			}
+			if err := mg.sbomWriter(sbomDocOutputFilename, &buf); err != nil {
+				return err
+			}
+		}
+	}
 
 	return nil
 }

--- a/test/test_container.py
+++ b/test/test_container.py
@@ -1,4 +1,6 @@
+import json
 import os
+import platform
 import subprocess
 
 import pytest
@@ -24,3 +26,29 @@ def test_container_builds_image(tmp_path, build_container, use_librepo):
     # XXX: ensure no other leftover dirs
     dents = os.listdir(output_dir)
     assert len(dents) == 1, f"too many dentries in output dir: {dents}"
+
+
+@pytest.mark.skipif(os.getuid() != 0, reason="needs root")
+def test_container_manifest_generates_sbom(tmp_path, build_container):
+    output_dir = tmp_path / "output"
+    output_dir.mkdir()
+    subprocess.check_call([
+        "podman", "run",
+        "--privileged",
+        "-v", f"{output_dir}:/output",
+        build_container,
+        "manifest",
+        "minimal-raw",
+        "--distro", "centos-9",
+        "--extra-artifacts=sbom",
+    ], stdout=subprocess.DEVNULL)
+    arch = platform.processor()
+    fn = f"centos-9-minimal-raw-{arch}/centos-9-minimal-raw-{arch}.image-os.spdx.json"
+    image_sbom_json_path = output_dir / fn
+    assert image_sbom_json_path.exists()
+    fn = f"centos-9-minimal-raw-{arch}/centos-9-minimal-raw-{arch}.buildroot-build.spdx.json"
+    buildroot_sbom_json_path = output_dir / fn
+    assert buildroot_sbom_json_path.exists()
+    sbom_json = json.loads(image_sbom_json_path.read_text())
+    # smoke test that we have glibc in the json doc
+    assert "glibc" in [s["name"] for s in sbom_json["Document"]["packages"]]


### PR DESCRIPTION
This commit adds an option to generate an sbom file via the
new `--export-sbom`option.

This to follows https://github.com/osbuild/osbuild-composer/pull/4359 and names the isboms `<image_filename>.<pipeline_purpose>-<pipeline_name>.spdx.json`

Once that is in we can do `--extra-artifacts=manifest` (this should be much simpler) and maybe later `extra-artifacts=buildlog`.

Closes: https://github.com/osbuild/image-builder-cli/issues/46

JIRA: RHELBU-3011
