### PR TITLE
spec: require osbuild

### DIFF
--- a/image-builder-cli.spec
+++ b/image-builder-cli.spec
@@ -52,6 +52,7 @@ BuildRequires:  btrfs-progs-devel
 %endif
 
 Requires:       osbuild
+Requires:       osbuild-depsolve-dnf
 
 %description
 %{common_description}

--- a/image-builder-cli.spec
+++ b/image-builder-cli.spec
@@ -51,11 +51,11 @@ BuildRequires:  btrfs-progs-devel
 # BUNDLE_END
 %endif
 
-Requires:   osbuild
-Requires:   osbuild-ostree
-Requires:   osbuild-lvm2
-Requires:   osbuild-luks2
-Requires:   osbuild-depsolve-dnf
+Requires:   osbuild >= %{min_osbuild_version}
+Requires:   osbuild-ostree >= %{min_osbuild_version}
+Requires:   osbuild-lvm2 >= %{min_osbuild_version}
+Requires:   osbuild-luks2 >= %{min_osbuild_version}
+Requires:   osbuild-depsolve-dnf >= %{min_osbuild_version}
 
 %description
 %{common_description}

--- a/image-builder-cli.spec
+++ b/image-builder-cli.spec
@@ -51,8 +51,11 @@ BuildRequires:  btrfs-progs-devel
 # BUNDLE_END
 %endif
 
-Requires:       osbuild
-Requires:       osbuild-depsolve-dnf
+Requires:   osbuild
+Requires:   osbuild-ostree
+Requires:   osbuild-lvm2
+Requires:   osbuild-luks2
+Requires:   osbuild-depsolve-dnf
 
 %description
 %{common_description}

--- a/image-builder-cli.spec
+++ b/image-builder-cli.spec
@@ -51,6 +51,8 @@ BuildRequires:  btrfs-progs-devel
 # BUNDLE_END
 %endif
 
+Requires:       osbuild
+
 %description
 %{common_description}
 


### PR DESCRIPTION
We can't build images without having osbuild installed.