### PR TITLE
fix up usage of cmd

### DIFF
--- a/cmd/image-builder/main.go
+++ b/cmd/image-builder/main.go
@@ -176,7 +176,7 @@ operating sytsems like centos and RHEL with easy customizations support.`,
 		Short:        "Build manifest for the given distro/image-type, e.g. centos-9 qcow2",
 		RunE:         cmdManifest,
 		SilenceUsage: true,
-		Args:         cobra.RangeArgs(1, 2),
+		Args:         cobra.ExactArgs(1),
 		Hidden:       true,
 	}
 	manifestCmd.Flags().String("blueprint", "", `blueprint to customize an image`)
@@ -192,7 +192,7 @@ operating sytsems like centos and RHEL with easy customizations support.`,
 		Short:        "Build the given distro/image-type, e.g. centos-9 qcow2",
 		RunE:         cmdBuild,
 		SilenceUsage: true,
-		Args:         cobra.RangeArgs(1, 2),
+		Args:         cobra.ExactArgs(1),
 	}
 	buildCmd.Flags().AddFlagSet(manifestCmd.Flags())
 	// XXX: add --rpmmd cache too and put under /var/cache/image-builder/dnf

--- a/cmd/image-builder/main.go
+++ b/cmd/image-builder/main.go
@@ -172,7 +172,7 @@ operating sytsems like centos and RHEL with easy customizations support.`,
 	rootCmd.AddCommand(listImagesCmd)
 
 	manifestCmd := &cobra.Command{
-		Use:          "manifest <image-type> [blueprint]",
+		Use:          "manifest <image-type>",
 		Short:        "Build manifest for the given distro/image-type, e.g. centos-9 qcow2",
 		RunE:         cmdManifest,
 		SilenceUsage: true,
@@ -188,7 +188,7 @@ operating sytsems like centos and RHEL with easy customizations support.`,
 	rootCmd.AddCommand(manifestCmd)
 
 	buildCmd := &cobra.Command{
-		Use:          "build <image-type> [blueprint]",
+		Use:          "build <image-type>",
 		Short:        "Build the given distro/image-type, e.g. centos-9 qcow2",
 		RunE:         cmdBuild,
 		SilenceUsage: true,


### PR DESCRIPTION
Fixes up the usage strings and argument counts for the build and manifest subcommands after we moved to `--blueprint`.