### PR TITLE
image-builder: newline in error message

### DIFF
--- a/cmd/image-builder/distro.go
+++ b/cmd/image-builder/distro.go
@@ -25,6 +25,6 @@ func findDistro(argDistroName, bpDistroName string) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("error deriving host distro %w", err)
 	}
-	fmt.Fprintf(osStderr, "No distro name specified, selecting %q based on host, use --distro to override", distroStr)
+	fmt.Fprintf(osStderr, "No distro name specified, selecting %q based on host, use --distro to override\n", distroStr)
 	return distroStr, nil
 }

--- a/cmd/image-builder/distro_test.go
+++ b/cmd/image-builder/distro_test.go
@@ -44,5 +44,5 @@ func TestFindDistroAutoDetect(t *testing.T) {
 	distro, err := main.FindDistro("", "")
 	assert.NoError(t, err)
 	assert.Equal(t, "mocked-host-distro", distro)
-	assert.Equal(t, `No distro name specified, selecting "mocked-host-distro" based on host, use --distro to override`, buf.String())
+	assert.Equal(t, "No distro name specified, selecting \"mocked-host-distro\" based on host, use --distro to override\n", buf.String())
 }


### PR DESCRIPTION
Fixes this:

```
€ go run ./cmd/image-builder build fedora-minimal
No distro name specified, selecting "fedora-41" based on host, use --distro to overrideerror: cannot find image for: distro:"fedora-41" type:"fedora-minimal" arch:"x86_64"
```

to this:

```
€ go run ./cmd/image-builder build fedora-minimal
No distro name specified, selecting "fedora-41" based on host, use --distro to override
error: cannot find image for: distro:"fedora-41" type:"fedora-minimal" arch:"x86_64"
```