### PR TITLE
spec: rename to `image-builder`

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -1,9 +1,9 @@
 # https://packit.dev/docs/configuration/
 
-specfile_path: image-builder-cli.spec
+specfile_path: image-builder.spec
 
 files_to_sync:
-  - image-builder-cli.spec
+  - image-builder.spec
   - .packit.yaml
 
 copy_upstream_release_description: true
@@ -24,7 +24,7 @@ actions:
 upstream_tag_include: 'v\d+'
 
 jobs:
-  # image-builder-cli is not yet in Fedora, so we don't need to update it there
+  # image-builder is not yet in Fedora, so we don't need to update it there
   # - job: bodhi_update
   #   trigger: commit
   #   dist_git_branches:
@@ -58,5 +58,5 @@ jobs:
     trigger: commit
     branch: main
     owner: "@osbuild"  # copr repo namespace
-    project: image-builder-cli  # copr repo name so you can consume the builds
+    project: image-builder  # copr repo name so you can consume the builds
     targets: *build_targets

--- a/HACKING.md
+++ b/HACKING.md
@@ -1,4 +1,4 @@
-# Hacking on image-builder-cli
+# Hacking on image-builder
 
 Hacking on `image-builder` should be fun and is easy.
 
@@ -15,7 +15,7 @@ To run the test suite install the test dependencies as outlined in the
 
 ## Code layout
 
-The go source code of image-builder-cli is under
+The go source code of image-builder is under
 `./cmd/image-builder`. It uses the
 [images](https://github.com/osbuild/images) library internally to
 generate the images. Unit tests (and integration tests where it makes

--- a/Makefile
+++ b/Makefile
@@ -49,8 +49,8 @@ GOLANGCI_COMPOSER_IMAGE=composer_golangci
 
 VERSION := $(shell ( git describe --tags --abbrev=0 2>/dev/null || echo v1 ) | sed 's|v||')
 COMMIT = $(shell (cd "$(SRCDIR)" && git rev-parse HEAD))
-PACKAGE_NAME_VERSION = image-builder-$(VERSION)
-PACKAGE_NAME_COMMIT = image-builder-$(COMMIT)
+PACKAGE_NAME_VERSION = image-builder-cli-$(VERSION)
+PACKAGE_NAME_COMMIT = image-builder-cli-$(COMMIT)
 
 #
 # Generic Targets

--- a/Makefile
+++ b/Makefile
@@ -49,8 +49,8 @@ GOLANGCI_COMPOSER_IMAGE=composer_golangci
 
 VERSION := $(shell ( git describe --tags --abbrev=0 2>/dev/null || echo v1 ) | sed 's|v||')
 COMMIT = $(shell (cd "$(SRCDIR)" && git rev-parse HEAD))
-PACKAGE_NAME_VERSION = image-builder-cli-$(VERSION)
-PACKAGE_NAME_COMMIT = image-builder-cli-$(COMMIT)
+PACKAGE_NAME_VERSION = image-builder-$(VERSION)
+PACKAGE_NAME_COMMIT = image-builder-$(COMMIT)
 
 #
 # Generic Targets
@@ -77,7 +77,7 @@ PACKAGE_NAME_COMMIT = image-builder-cli-$(COMMIT)
 help:
 	@echo "make [TARGETS...]"
 	@echo
-	@echo "This is the maintenance makefile of image-builder-cli. The following"
+	@echo "This is the maintenance makefile of image-builder. The following"
 	@echo "targets are available:"
 	@echo
 	@echo "    help:               Print this usage information."
@@ -114,7 +114,7 @@ clean:
 #
 # Building packages
 #
-# The following rules build image-builder-cli packages from the current HEAD
+# The following rules build image-builder packages from the current HEAD
 # commit, based on the spec file in this directory.  The resulting packages
 # have the commit hash in their version, so that they don't get overwritten
 # when calling `make rpm` again after switching to another branch.
@@ -123,14 +123,14 @@ clean:
 # ./rpmbuild, using rpmbuild's usual directory structure.
 #
 
-RPM_SPECFILE=rpmbuild/SPECS/image-builder-cli.spec
+RPM_SPECFILE=rpmbuild/SPECS/image-builder.spec
 RPM_TARBALL=rpmbuild/SOURCES/$(PACKAGE_NAME_COMMIT).tar.gz
 RPM_TARBALL_VERSIONED=rpmbuild/SOURCES/$(PACKAGE_NAME_VERSION).tar.gz
 
 .PHONY: $(RPM_SPECFILE)
 $(RPM_SPECFILE):
 	mkdir -p $(CURDIR)/rpmbuild/SPECS
-	git show HEAD:image-builder-cli.spec > $(RPM_SPECFILE)
+	git show HEAD:image-builder.spec > $(RPM_SPECFILE)
 	go mod vendor
 	./tools/rpm_spec_add_provides_bundle.sh $(RPM_SPECFILE)
 

--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ $ sudo podman run --privileged \
 This project is under development right now and we provide up-to-date
 development snapshots in the following way:
 
-A copr RPM build
-https://copr.fedorainfracloud.org/coprs/g/osbuild/image-builder-cli/
+A COPR RPM build
+https://copr.fedorainfracloud.org/coprs/g/osbuild/image-builder/
 
 Via the go build system:
 ```console

--- a/image-builder.spec
+++ b/image-builder.spec
@@ -17,16 +17,13 @@ Version:        5
 %gometa
 
 %global common_description %{expand:
-A service for building customized OS artifacts, such as VM images and OSTree
-commits, that uses osbuild under the hood. Besides building images for local
-usage, it can also upload images directly to cloud.
-
-It is compatible with composer-cli and cockpit-composer clients.
+A local binary for building customized OS artifacts such as VM images and
+OSTree commits. Uses osbuild under the hood.
 }
 
 Name:           image-builder
 Release:        1%{?dist}
-Summary:        An image building service based on osbuild
+Summary:        An image building executable using osbuild
 ExcludeArch:    i686 armv7hl
 
 # Upstream license specification: Apache-2.0

--- a/image-builder.spec
+++ b/image-builder.spec
@@ -24,7 +24,7 @@ usage, it can also upload images directly to cloud.
 It is compatible with composer-cli and cockpit-composer clients.
 }
 
-Name:           image-builder-cli
+Name:           image-builder
 Release:        1%{?dist}
 Summary:        An image building service based on osbuild
 ExcludeArch:    i686 armv7hl

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -8,7 +8,7 @@ import pytest
 def build_container_fixture():
     """Build a container from the Containerfile and returns the name"""
 
-    container_tag = "image-builder-cli-test"
+    container_tag = "image-builder-test"
     subprocess.check_call([
         "podman", "build",
         "-f", "Containerfile",

--- a/tools/rpm_spec_add_provides_bundle.sh
+++ b/tools/rpm_spec_add_provides_bundle.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/bash
 
-SPEC_FILE=${1:-"image-builder-cli.spec"}
+SPEC_FILE=${1:-"image-builder.spec"}
 
 # Save the list of bundled packages into a file
 WORKDIR=$(mktemp -d)


### PR DESCRIPTION
`image-builder` will be the main entrypoint into the Image Builder stack. We will rename the repositories later on; but let's start referring to it in its new official name.