### PR TITLE
main: add `--extra-artifacts=manifest`

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,10 @@ $ sudo image-builder build qcow2 --distro centos-9
 this will create a directory `centos-9-qcow2-x86_64` under which the
 output is stored.
 
+With the `--extra-artifacts=manifest` an
+[osbuild](https://github.com/osbuild/osbuild) manifest will be
+placed in the output directory too.
+
 ### Blueprints
 
 Blueprints are supported, first create a `config.toml` and put e.g.

--- a/cmd/image-builder/build.go
+++ b/cmd/image-builder/build.go
@@ -1,6 +1,10 @@
 package main
 
 import (
+	"fmt"
+	"os"
+	"path/filepath"
+
 	"github.com/osbuild/images/pkg/imagefilter"
 	"github.com/osbuild/images/pkg/osbuild"
 )
@@ -8,6 +12,8 @@ import (
 type buildOptions struct {
 	OutputDir string
 	StoreDir  string
+
+	WriteManifest bool
 }
 
 func buildImage(res *imagefilter.Result, osbuildManifest []byte, opts *buildOptions) error {
@@ -18,7 +24,13 @@ func buildImage(res *imagefilter.Result, osbuildManifest []byte, opts *buildOpti
 	// XXX: support output filename via commandline (c.f.
 	//   https://github.com/osbuild/images/pull/1039)
 	if opts.OutputDir == "" {
-		opts.OutputDir = outputDirFor(res)
+		opts.OutputDir = outputNameFor(res)
+	}
+	if opts.WriteManifest {
+		p := filepath.Join(opts.OutputDir, fmt.Sprintf("%s.osbuild-manifest.json", outputNameFor(res)))
+		if err := os.WriteFile(p, osbuildManifest, 0644); err != nil {
+			return err
+		}
 	}
 
 	// XXX: support stremaing via images/pkg/osbuild/monitor.go

--- a/cmd/image-builder/build.go
+++ b/cmd/image-builder/build.go
@@ -5,15 +5,24 @@ import (
 	"github.com/osbuild/images/pkg/osbuild"
 )
 
-func buildImage(res *imagefilter.Result, osbuildManifest []byte, osbuildStoreDir, outputDir string) error {
+type buildOptions struct {
+	OutputDir string
+	StoreDir  string
+}
+
+func buildImage(res *imagefilter.Result, osbuildManifest []byte, opts *buildOptions) error {
+	if opts == nil {
+		opts = &buildOptions{}
+	}
+
 	// XXX: support output filename via commandline (c.f.
 	//   https://github.com/osbuild/images/pull/1039)
-	if outputDir == "" {
-		outputDir = outputDirFor(res)
+	if opts.OutputDir == "" {
+		opts.OutputDir = outputDirFor(res)
 	}
 
 	// XXX: support stremaing via images/pkg/osbuild/monitor.go
-	_, err := osbuild.RunOSBuild(osbuildManifest, osbuildStoreDir, outputDir, res.ImgType.Exports(), nil, nil, false, osStderr)
+	_, err := osbuild.RunOSBuild(osbuildManifest, opts.StoreDir, opts.OutputDir, res.ImgType.Exports(), nil, nil, false, osStderr)
 	return err
 
 }

--- a/cmd/image-builder/main.go
+++ b/cmd/image-builder/main.go
@@ -171,7 +171,11 @@ func cmdBuild(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	return buildImage(res, mf.Bytes(), storeDir, outputDir)
+	buildOpts := &buildOptions{
+		OutputDir: outputDir,
+		StoreDir:  storeDir,
+	}
+	return buildImage(res, mf.Bytes(), buildOpts)
 }
 
 func run() error {

--- a/cmd/image-builder/manifest.go
+++ b/cmd/image-builder/manifest.go
@@ -49,7 +49,7 @@ func generateManifest(dataDir string, img *imagefilter.Result, output io.Writer,
 	if slices.Contains(opts.ExtraArtifacts, "sbom") {
 		outputDir := opts.OutputDir
 		if outputDir == "" {
-			outputDir = outputDirFor(img)
+			outputDir = outputNameFor(img)
 		}
 		if err := os.MkdirAll(outputDir, 0755); err != nil {
 			return err


### PR DESCRIPTION
This commit adds support for `--extra-artifacts=manifest`. If
that is given as part of the build an extra artifacts called
`<img-name>.osbuild-manifest.json` will be created in the
output directory.

Closes: https://github.com/osbuild/image-builder-cli/issues/42
