### PR TITLE
spec: use go-vendor-tools to generate license

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -17,7 +17,7 @@ srpm_build_deps:
 actions:
   # v1 just the default prior to having tags
   get-current-version: bash -c "make show-version"
-  post-upstream-clone: bash -c "go mod vendor && ./tools/rpm_spec_add_provides_bundle.sh"
+  post-upstream-clone: bash -c "GOPROXY=https://proxy.golang.org,direct go mod vendor && ./tools/rpm_spec_add_provides_bundle.sh"
   create-archive: bash -c "make release_artifacts"
 
 # Handle only releases without a "dot" (e.g. v88.2), since "dot" releases should never be released to Fedora

--- a/go-vendor-tools.toml
+++ b/go-vendor-tools.toml
@@ -1,0 +1,13 @@
+# See: https://fedora.gitlab.io/sigs/go/go-vendor-tools/config/#licenses-list-of-license-entry-tables
+
+# These files' licenses can't be autodetected by `go-vendor-tools`; we need to list
+# them manually.
+
+[[licensing.licenses]]
+path = "vendor/gopkg.in/yaml.v3/LICENSE"
+sha256sum = "d18f6323b71b0b768bb5e9616e36da390fbd39369a81807cca352de4e4e6aa0b"
+expression = "Apache-2.0 AND MIT"
+[[licensing.licenses]]
+path = "vendor/github.com/go-openapi/spec/license.go"
+sha256sum = "9ba36f66fba6f2e3b7dce95d9413a738688abcfce8c3d38c581b276f9437d1c6"
+expression = "Apache-2.0"

--- a/image-builder.spec
+++ b/image-builder.spec
@@ -27,7 +27,10 @@ Summary:        An image building executable using osbuild
 ExcludeArch:    i686 armv7hl
 
 # Upstream license specification: Apache-2.0
-License:        Apache-2.0
+# Others generated with:
+#   $ go_vendor_license -C <UNPACKED ARCHIVE> report expression
+License:        Apache-2.0 AND BSD-2-Clause AND BSD-3-Clause AND CC-BY-SA-4.0 AND ISC AND MIT AND MPL-2.0 AND Unlicense
+
 URL:            %{gourl}
 Source0:        %{gosource}
 


### PR DESCRIPTION
Use go-vendor-tools to generate the license identifiers for our vendored code. This initial commit does not yet apply the rest of go-vendor-tools abilities to manage the vendoring itself.

There will be more followup work required to enable the `go-vendor-tools` macros but this first step lists all licenses from vendored code.