### PR TITLE
packit: set default for GOPROXY

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -18,7 +18,7 @@ srpm_build_deps:
 actions:
   # v1 just the default prior to having tags
   get-current-version: bash -c "make show-version"
-  post-upstream-clone: bash -c "GOPROXY=https://proxy.golang.org,direct go mod vendor && ./tools/rpm_spec_add_provides_bundle.sh"
+  post-upstream-clone: bash -c "make GOPROXY='https://proxy.golang.org,direct' patch-spec-in-place"
   create-archive: bash -c "make release_artifacts"
 
 # Handle only releases without a "dot" (e.g. v88.2), since "dot" releases should never be released to Fedora

--- a/Makefile
+++ b/Makefile
@@ -118,16 +118,21 @@ clean:  ## Remove all built binaries
 # ./rpmbuild, using rpmbuild's usual directory structure.
 #
 
-RPM_SPECFILE=rpmbuild/SPECS/image-builder.spec
+RPM_SPECFILE_NAME=image-builder.spec
+RPM_SPECFILE=rpmbuild/SPECS/$(RPM_SPECFILE_NAME)
 RPM_TARBALL=rpmbuild/SOURCES/$(PACKAGE_NAME_COMMIT).tar.gz
 RPM_TARBALL_VERSIONED=rpmbuild/SOURCES/$(PACKAGE_NAME_VERSION).tar.gz
 
 .PHONY: $(RPM_SPECFILE)
 $(RPM_SPECFILE):
 	mkdir -p $(CURDIR)/rpmbuild/SPECS
-	git show HEAD:image-builder.spec > $(RPM_SPECFILE)
+	git show HEAD:$(RPM_SPECFILE_NAME) > $(RPM_SPECFILE)
 	go mod vendor
 	./tools/rpm_spec_add_provides_bundle.sh $(RPM_SPECFILE)
+
+.PHONY: patch-spec-in-place
+patch-spec-in-place: $(RPM_SPECFILE) ## patch image-builder.spec in-place for build systems
+	cp $< $(RPM_SPECFILE_NAME)
 
 # This is the syntax to essentially get
 # either PACKAGE_NAME_COMMIT or PACKAGE_NAME_VERSION dynamically


### PR DESCRIPTION
The default in our CI is "direct" which is not as stable as the more common `https://proxy.golang.org,direct`.

This also moves the implementation to the `Makefile` to have it more central.
