### PR TITLE
cmd/image-builder/main: improve wording of `--blueprint` help

### DIFF
--- a/cmd/image-builder/main.go
+++ b/cmd/image-builder/main.go
@@ -223,7 +223,7 @@ operating sytsems like centos and RHEL with easy customizations support.`,
 		Args:         cobra.ExactArgs(1),
 		Hidden:       true,
 	}
-	manifestCmd.Flags().String("blueprint", "", `blueprint to customize an image`)
+	manifestCmd.Flags().String("blueprint", "", `filename of a blueprint to customize an image`)
 	manifestCmd.Flags().String("arch", "", `build manifest for a different architecture`)
 	manifestCmd.Flags().String("distro", "", `build manifest for a different distroname (e.g. centos-9)`)
 	manifestCmd.Flags().String("ostree-ref", "", `OSTREE reference`)


### PR DESCRIPTION
When reading `--blueprint string` I briefly thought it might also be possible to put a whole blueprint content as string into image-builder-cli argument 😕

This wording should avoid misunderstandings.