### PR TITLE
deps: update `images`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ go 1.21.0
 require (
 	github.com/BurntSushi/toml v1.4.0
 	github.com/gobwas/glob v0.2.3
-	github.com/osbuild/images v0.109.1-0.20250117082457-97ca7c62eb09
+	github.com/osbuild/images v0.111.1-0.20250124075826-58bc61d3c5d9
 	github.com/sirupsen/logrus v1.9.3
 	github.com/spf13/cobra v1.8.1
 	github.com/stretchr/testify v1.10.0

--- a/go.sum
+++ b/go.sum
@@ -212,6 +212,10 @@ github.com/opencontainers/selinux v1.11.0 h1:+5Zbo97w3Lbmb3PeqQtpmTkMwsW5nRI3YaL
 github.com/opencontainers/selinux v1.11.0/go.mod h1:E5dMC3VPuVvVHDYmi78qvhJp8+M586T4DlDRYpFkyec=
 github.com/osbuild/images v0.109.1-0.20250117082457-97ca7c62eb09 h1:9ABt4zMJ6tNp1+AHI4FrDq1Fxy/l5uYuDXs6EOR6QJ0=
 github.com/osbuild/images v0.109.1-0.20250117082457-97ca7c62eb09/go.mod h1:58tzp7jV50rjaH9gMpvmQdVati0c4TaC5Op7wmSD/tY=
+github.com/osbuild/images v0.111.0 h1:mnPLdSin/q1ZTaGZVJHepsikguFjUMAWblQdPgvZ02M=
+github.com/osbuild/images v0.111.0/go.mod h1:58tzp7jV50rjaH9gMpvmQdVati0c4TaC5Op7wmSD/tY=
+github.com/osbuild/images v0.111.1-0.20250124075826-58bc61d3c5d9 h1:+VfE3f5vhQLLJBfcgXgEd5Ah04pLpXwXD4jRb73GxEM=
+github.com/osbuild/images v0.111.1-0.20250124075826-58bc61d3c5d9/go.mod h1:58tzp7jV50rjaH9gMpvmQdVati0c4TaC5Op7wmSD/tY=
 github.com/ostreedev/ostree-go v0.0.0-20210805093236-719684c64e4f h1:/UDgs8FGMqwnHagNDPGOlts35QkhAZ8by3DR7nMih7M=
 github.com/ostreedev/ostree-go v0.0.0-20210805093236-719684c64e4f/go.mod h1:J6OG6YJVEWopen4avK3VNQSnALmmjvniMmni/YFYAwc=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=


### PR DESCRIPTION
Update images to understand the `main` of `osbuild` that we integration test against.

After the package has landed in Fedora (see #88) I'll be updating the specfile to also use the dnf-json API version.