### PR TITLE
test: switch to `platform.machine`

### DIFF
--- a/test/test_container.py
+++ b/test/test_container.py
@@ -42,7 +42,7 @@ def test_container_manifest_generates_sbom(tmp_path, build_container):
         "--distro", "centos-9",
         "--with-sbom",
     ], stdout=subprocess.DEVNULL)
-    arch = platform.processor()
+    arch = platform.machine()
     fn = f"centos-9-minimal-raw-{arch}/centos-9-minimal-raw-{arch}.image-os.spdx.json"
     image_sbom_json_path = output_dir / fn
     assert image_sbom_json_path.exists()


### PR DESCRIPTION
For some reason on a bunch of my systems `platform.processor()` always returns an empty string. `platform.machine()` consistently works on those systems.

This closes #95.