### PR TITLE
image-builder: create directory

### DIFF
--- a/cmd/image-builder/build.go
+++ b/cmd/image-builder/build.go
@@ -28,6 +28,9 @@ func buildImage(res *imagefilter.Result, osbuildManifest []byte, opts *buildOpti
 	}
 	if opts.WriteManifest {
 		p := filepath.Join(opts.OutputDir, fmt.Sprintf("%s.osbuild-manifest.json", outputNameFor(res)))
+		if err := os.MkdirAll(filepath.Dir(p), 0755); err != nil {
+			return err
+		}
 		if err := os.WriteFile(p, osbuildManifest, 0644); err != nil {
 			return err
 		}

--- a/cmd/image-builder/manifest.go
+++ b/cmd/image-builder/manifest.go
@@ -25,6 +25,9 @@ type manifestOptions struct {
 
 func sbomWriter(outputDir, filename string, content io.Reader) error {
 	p := filepath.Join(outputDir, filename)
+	if err := os.MkdirAll(filepath.Dir(p), 0755); err != nil {
+		return err
+	}
 	f, err := os.Create(p)
 	if err != nil {
 		return err
@@ -50,9 +53,6 @@ func generateManifest(dataDir string, img *imagefilter.Result, output io.Writer,
 		outputDir := opts.OutputDir
 		if outputDir == "" {
 			outputDir = outputNameFor(img)
-		}
-		if err := os.MkdirAll(outputDir, 0755); err != nil {
-			return err
 		}
 		manifestGenOpts.SBOMWriter = func(filename string, content io.Reader, docType sbom.StandardType) error {
 			return sbomWriter(outputDir, filename, content)


### PR DESCRIPTION
Create the output directory; this is a no-op if it already exists but fixes #94 if it doesn't. The code is similar to (but not identical to) the checks done in `cmd/image-builder/manifest.go` for the `withSBOM` parts.

We might (or I) might want to consolidate those two codepaths either here in a followup.
