### PR TITLE
README: add FAQ about relation between `bib` and `ibcli`

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,12 @@ A: Sure! The repositories are encoded in json in "<distro>-<vesion>.json",
    "--datadir ~/my-project --distro foo-1" a json file must be put under
    "~/my-project/repositories/foo-1.json.
 
+Q: What is the relation to [bootc-image-builder](https://github.com/osbuild/bootc-image-builder)?
+A: Both projects are very close. The `bootc-image-builder` focuses on providing
+   image-based artifacts while `image-builder` works with traditional package
+   based inputs. We expect the two projects to merge eventually and they already
+   share a lot of code.
+
 ## Project
 
  * **Website**: <https://www.osbuild.org>


### PR DESCRIPTION
This commit adds a small FAQ entry to explain the relation between `bib` and `ibcli`.

Thanks to Jonathan Lebon for the suggesiton.

Closes: https://github.com/osbuild/image-builder-cli/issues/89