### PR TITLE
main: tweak the help of `manifest` and `build`

### DIFF
--- a/cmd/image-builder/main.go
+++ b/cmd/image-builder/main.go
@@ -235,7 +235,7 @@ operating systems like Fedora, CentOS and RHEL with easy customizations support.
 
 	manifestCmd := &cobra.Command{
 		Use:          "manifest <image-type>",
-		Short:        "Build manifest for the given distro/image-type, e.g. centos-9 qcow2",
+		Short:        "Build manifest for the given image-type, e.g. qcow2 (tip: combine with --distro, --arch)",
 		RunE:         cmdManifest,
 		SilenceUsage: true,
 		Args:         cobra.ExactArgs(1),
@@ -253,7 +253,7 @@ operating systems like Fedora, CentOS and RHEL with easy customizations support.
 
 	buildCmd := &cobra.Command{
 		Use:          "build <image-type>",
-		Short:        "Build the given distro/image-type, e.g. centos-9 qcow2",
+		Short:        "Build the given image-type, e.g. qcow2 (tip: combine with --distro, --arch)",
 		RunE:         cmdBuild,
 		SilenceUsage: true,
 		Args:         cobra.ExactArgs(1),


### PR DESCRIPTION
This commit tweaks the help output for the manifest and build commands to make clear that only the image type is a required argument but the rest can be overriden via extra flags.

Thanks to Achilleas for noticing.