### PR TITLE
main: silence all logrus logging for now

### DIFF
--- a/cmd/image-builder/main.go
+++ b/cmd/image-builder/main.go
@@ -203,9 +203,13 @@ func cmdBuild(cmd *cobra.Command, args []string) error {
 }
 
 func run() error {
-	// images logs a bunch of stuff to Debug/Info that is distracting
-	// the user (at least by default, like what repos being loaded)
-	logrus.SetLevel(logrus.WarnLevel)
+	// images generates a lot of noisy logs a bunch of stuff to
+	// Debug/Info that is distracting the user (at least by
+	// default, like what repos being loaded)
+	//
+	// Disable for now until we can filter out the usless log
+	// messages.
+	logrus.SetOutput(io.Discard)
 
 	rootCmd := &cobra.Command{
 		Use:   "image-builder",


### PR DESCRIPTION
This commit silences logrus logging for now by just dicarding everything from it. The rational is that the underlying libraries produce a lot of output, e.g. every build currently results in
```console
$ image-builder build qcow2
WARN[0000] Failed to load consumer certs: no consumer key found
...
```
which is confusing to our users. What is worse is that containers also uses logrus so we can get random warnings without context from there too. Until we have a way to filter log messages this seems to be the most practical way.

We can add `--verbose` or `--debug` later to enable these kinds of messages.