### PR TITLE
ci/packit: set downstream name

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -1,6 +1,7 @@
 # https://packit.dev/docs/configuration/
 
 specfile_path: image-builder.spec
+downstream_package_name: image-builder
 
 files_to_sync:
   - image-builder.spec


### PR DESCRIPTION
Since our upstream repository name differs from the downstream name we should set the `downstream_package_name` [1] config option.

[1]: https://packit.dev/docs/configuration#downstream_package_name