### PR TITLE
specfile: build requires `libxcrypt-compat`

### DIFF
--- a/image-builder.spec
+++ b/image-builder.spec
@@ -36,6 +36,7 @@ BuildRequires:  gpgme-devel
 BuildRequires:  libassuan-devel
 # Build requirements of 'github.com/containers/storage' package
 BuildRequires:  device-mapper-devel
+BuildRequires:  libxcrypt-devel
 %if 0%{?fedora}
 # Build requirements of 'github.com/containers/storage' package
 BuildRequires:  btrfs-progs-devel


### PR DESCRIPTION
We received a commit downstream by Björn Esser. After asking around for the reasoning behind the commit it seems that we're likely assuming that this package is available in the buildroot.

Let's depend on it explicitly instead of assuming it is there.