### PR TITLE
main: add new upload command

### DIFF
--- a/.spellcheck-en-custom.txt
+++ b/.spellcheck-en-custom.txt
@@ -1,3 +1,4 @@
+ami
 backend
 bootc
 bootmode

--- a/README.md
+++ b/README.md
@@ -114,6 +114,22 @@ It is possible to generate spdx based SBOM (software bill of materials)
 documents as part of the build. Just pass `--with-sbom` and
 it will put them into the output directory.
 
+### Cloud integration
+
+When building an image type that can be uploaded to the cloud
+(e.g. an "ami") image-builder will automatically upload if
+all cloud parameters are provided, e.g.
+```
+$ image-builder build ami --distro centos-9 \
+    --aws-region us-east-1 \
+	--aws-bucket example-bucket \
+	--aws-ami-name my-image-1
+```
+Images can also be uploaded with the `image-builder upload` command
+after they are built.
+
+
+
 ### Filtering
 
 When listing images, it is possible to filter:

--- a/cmd/image-builder/build.go
+++ b/cmd/image-builder/build.go
@@ -21,11 +21,6 @@ func buildImage(pbar progress.ProgressBar, res *imagefilter.Result, osbuildManif
 		opts = &buildOptions{}
 	}
 
-	// XXX: support output filename via commandline (c.f.
-	//   https://github.com/osbuild/images/pull/1039)
-	if opts.OutputDir == "" {
-		opts.OutputDir = outputNameFor(res)
-	}
 	if opts.WriteManifest {
 		p := filepath.Join(opts.OutputDir, fmt.Sprintf("%s.osbuild-manifest.json", outputNameFor(res)))
 		if err := os.MkdirAll(filepath.Dir(p), 0755); err != nil {

--- a/cmd/image-builder/export_test.go
+++ b/cmd/image-builder/export_test.go
@@ -5,6 +5,8 @@ import (
 	"io"
 	"os"
 
+	"github.com/osbuild/images/pkg/cloud"
+	"github.com/osbuild/images/pkg/cloud/awscloud"
 	"github.com/osbuild/images/pkg/reporegistry"
 )
 
@@ -58,5 +60,13 @@ func MockDistroGetHostDistroName(f func() (string, error)) (restore func()) {
 	distroGetHostDistroName = f
 	return func() {
 		distroGetHostDistroName = saved
+	}
+}
+
+func MockAwscloudNewUploader(f func(string, string, string, *awscloud.UploaderOptions) (cloud.Uploader, error)) (restore func()) {
+	saved := awscloudNewUploader
+	awscloudNewUploader = f
+	return func() {
+		awscloudNewUploader = saved
 	}
 }

--- a/cmd/image-builder/main_test.go
+++ b/cmd/image-builder/main_test.go
@@ -15,8 +15,10 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
-	//"github.com/osbuild/bootc-image-builder/bib/pkg/progress"
+	"github.com/osbuild/images/pkg/cloud"
+	"github.com/osbuild/images/pkg/cloud/awscloud"
 	testrepos "github.com/osbuild/images/test/data/repositories"
 
 	main "github.com/osbuild/image-builder-cli/cmd/image-builder"
@@ -599,4 +601,65 @@ func TestProgressFromCmd(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, tc.expectedProgress, fmt.Sprintf("%T", pbar))
 	}
+}
+
+type fakeAwsUploader struct {
+	checkCalls int
+
+	uploadAndRegisterRead  bytes.Buffer
+	uploadAndRegisterCalls int
+}
+
+var _ = cloud.Uploader(&fakeAwsUploader{})
+
+func (fa *fakeAwsUploader) Check(status io.Writer) error {
+	fa.checkCalls++
+	return nil
+}
+
+func (fa *fakeAwsUploader) UploadAndRegister(r io.Reader, status io.Writer) error {
+	fa.uploadAndRegisterCalls++
+	_, err := io.Copy(&fa.uploadAndRegisterRead, r)
+	return err
+}
+
+func TestUploadWithAWSMock(t *testing.T) {
+	fakeDiskContent := "fake-raw-img"
+
+	fakeImageFilePath := filepath.Join(t.TempDir(), "disk.raw")
+	err := os.WriteFile(fakeImageFilePath, []byte(fakeDiskContent), 0644)
+	assert.NoError(t, err)
+
+	var regionName, bucketName, amiName string
+	var fa fakeAwsUploader
+	restore := main.MockAwscloudNewUploader(func(region string, bucket string, ami string, opts *awscloud.UploaderOptions) (cloud.Uploader, error) {
+		regionName = region
+		bucketName = bucket
+		amiName = ami
+		return &fa, nil
+	})
+	defer restore()
+
+	var fakeStdout bytes.Buffer
+	restore = main.MockOsStdout(&fakeStdout)
+	defer restore()
+
+	restore = main.MockOsArgs([]string{
+		"upload",
+		"--to=aws",
+		"--aws-region=aws-region-1",
+		"--aws-bucket=aws-bucket-2",
+		"--aws-ami-name=aws-ami-3",
+		fakeImageFilePath,
+	})
+	err = main.Run()
+	require.NoError(t, err)
+
+	assert.Equal(t, regionName, "aws-region-1")
+	assert.Equal(t, bucketName, "aws-bucket-2")
+	assert.Equal(t, amiName, "aws-ami-3")
+
+	assert.Equal(t, fakeDiskContent, fa.uploadAndRegisterRead.String())
+	// progress was rendered
+	assert.Contains(t, fakeStdout.String(), "--] 100.00%")
 }

--- a/cmd/image-builder/upload.go
+++ b/cmd/image-builder/upload.go
@@ -1,0 +1,132 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/cheggaaa/pb/v3"
+	"github.com/spf13/cobra"
+
+	"github.com/osbuild/bootc-image-builder/bib/pkg/progress"
+	"github.com/osbuild/images/pkg/cloud"
+	"github.com/osbuild/images/pkg/cloud/awscloud"
+)
+
+type MissingUploadConfigError struct {
+	missing    []string
+	allMissing bool
+}
+
+func (e *MissingUploadConfigError) Error() string {
+	return fmt.Sprintf("missing upload configuration: %q", e.missing)
+}
+
+type UploadTypeUnsupportedError struct {
+	typ string
+}
+
+func (e *UploadTypeUnsupportedError) Error() string {
+	return fmt.Sprintf("unsupported upload type %q", e.typ)
+}
+
+var awscloudNewUploader = awscloud.NewUploader
+
+func uploadImageWithProgress(uploader cloud.Uploader, imagePath string) error {
+	f, err := os.Open(imagePath)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	// setup basic progress
+	st, err := f.Stat()
+	if err != nil {
+		return fmt.Errorf("cannot stat upload: %v", err)
+	}
+	pbar := pb.New64(st.Size())
+	pbar.Set(pb.Bytes, true)
+	pbar.SetWriter(osStdout)
+	r := pbar.NewProxyReader(f)
+	pbar.Start()
+	defer pbar.Finish()
+
+	return uploader.UploadAndRegister(r, osStderr)
+}
+
+func uploaderCheckWithProgress(pbar progress.ProgressBar, uploader cloud.Uploader) error {
+	pr, pw := io.Pipe()
+	defer pw.Close()
+
+	go func() {
+		scanner := bufio.NewScanner(pr)
+		for scanner.Scan() {
+			pbar.SetMessagef("%s", scanner.Text())
+		}
+	}()
+	return uploader.Check(pw)
+}
+
+func uploaderFor(cmd *cobra.Command, typeOrCloud string) (cloud.Uploader, error) {
+	switch typeOrCloud {
+	case "ami", "aws":
+		return uploaderForCmdAWS(cmd)
+	default:
+		return nil, &UploadTypeUnsupportedError{typeOrCloud}
+	}
+
+}
+
+func uploaderForCmdAWS(cmd *cobra.Command) (cloud.Uploader, error) {
+	amiName, err := cmd.Flags().GetString("aws-ami-name")
+	if err != nil {
+		return nil, err
+	}
+	bucketName, err := cmd.Flags().GetString("aws-bucket")
+	if err != nil {
+		return nil, err
+	}
+	region, err := cmd.Flags().GetString("aws-region")
+	if err != nil {
+		return nil, err
+	}
+
+	var missing []string
+	requiredArgs := []string{"aws-ami-name", "aws-bucket", "aws-region"}
+	for _, argName := range requiredArgs {
+		arg, err := cmd.Flags().GetString(argName)
+		if err != nil {
+			return nil, err
+		}
+		if arg == "" {
+			missing = append(missing, fmt.Sprintf("--%s", argName))
+		}
+	}
+	if len(missing) > 0 {
+		return nil, &MissingUploadConfigError{
+			missing:    missing,
+			allMissing: len(missing) == len(requiredArgs),
+		}
+	}
+
+	return awscloudNewUploader(region, bucketName, amiName, nil)
+}
+
+func cmdUpload(cmd *cobra.Command, args []string) error {
+	uploadTo, err := cmd.Flags().GetString("to")
+	if err != nil {
+		return err
+	}
+	if uploadTo == "" {
+		return fmt.Errorf("missing --to parameter, try --to=aws")
+	}
+
+	imagePath := args[0]
+	uploader, err := uploaderFor(cmd, uploadTo)
+	if err != nil {
+		return err
+	}
+
+	return uploadImageWithProgress(uploader, imagePath)
+}

--- a/cmd/image-builder/upload_test.go
+++ b/cmd/image-builder/upload_test.go
@@ -1,0 +1,246 @@
+package main_test
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/osbuild/images/pkg/cloud"
+	"github.com/osbuild/images/pkg/cloud/awscloud"
+
+	main "github.com/osbuild/image-builder-cli/cmd/image-builder"
+	"github.com/osbuild/image-builder-cli/internal/testutil"
+)
+
+type fakeAwsUploader struct {
+	checkCalls int
+
+	uploadAndRegisterRead  bytes.Buffer
+	uploadAndRegisterCalls int
+	uploadAndRegisterErr   error
+}
+
+var _ = cloud.Uploader(&fakeAwsUploader{})
+
+func (fa *fakeAwsUploader) Check(status io.Writer) error {
+	fa.checkCalls++
+	return nil
+}
+
+func (fa *fakeAwsUploader) UploadAndRegister(r io.Reader, status io.Writer) error {
+	fa.uploadAndRegisterCalls++
+	_, err := io.Copy(&fa.uploadAndRegisterRead, r)
+	if err != nil {
+		panic(err)
+	}
+	return fa.uploadAndRegisterErr
+}
+
+func TestUploadWithAWSMock(t *testing.T) {
+	fakeDiskContent := "fake-raw-img"
+
+	fakeImageFilePath := filepath.Join(t.TempDir(), "disk.raw")
+	err := os.WriteFile(fakeImageFilePath, []byte(fakeDiskContent), 0644)
+	assert.NoError(t, err)
+
+	var regionName, bucketName, amiName string
+	var fa fakeAwsUploader
+	restore := main.MockAwscloudNewUploader(func(region string, bucket string, ami string, opts *awscloud.UploaderOptions) (cloud.Uploader, error) {
+		regionName = region
+		bucketName = bucket
+		amiName = ami
+		return &fa, nil
+	})
+	defer restore()
+
+	var fakeStdout bytes.Buffer
+	restore = main.MockOsStdout(&fakeStdout)
+	defer restore()
+
+	restore = main.MockOsArgs([]string{
+		"upload",
+		"--to=aws",
+		"--aws-region=aws-region-1",
+		"--aws-bucket=aws-bucket-2",
+		"--aws-ami-name=aws-ami-3",
+		fakeImageFilePath,
+	})
+	defer restore()
+
+	err = main.Run()
+	require.NoError(t, err)
+
+	assert.Equal(t, regionName, "aws-region-1")
+	assert.Equal(t, bucketName, "aws-bucket-2")
+	assert.Equal(t, amiName, "aws-ami-3")
+
+	assert.Equal(t, 0, fa.checkCalls)
+	assert.Equal(t, 1, fa.uploadAndRegisterCalls)
+	assert.Equal(t, fakeDiskContent, fa.uploadAndRegisterRead.String())
+	// progress was rendered
+	assert.Contains(t, fakeStdout.String(), "--] 100.00%")
+}
+
+func TestUploadCmdlineErrors(t *testing.T) {
+	for _, tc := range []struct {
+		cmdline     []string
+		expectedErr string
+	}{
+		{
+			nil,
+			`missing --to parameter, try --to=aws`,
+		}, {
+			[]string{"--to=aws"},
+			`missing upload configuration: ["--aws-ami-name" "--aws-bucket" "--aws-region"]`,
+		},
+		{
+			[]string{"--to=aws", "--aws-ami-name=1"},
+			`missing upload configuration: ["--aws-bucket" "--aws-region"]`,
+		},
+		{
+			[]string{"--to=aws", "--aws-ami-name=1", "--aws-bucket=2"},
+			`missing upload configuration: ["--aws-region"]`,
+		},
+	} {
+		t.Run(strings.Join(tc.cmdline, ","), func(t *testing.T) {
+			cmd := append([]string{"upload"}, tc.cmdline...)
+			cmd = append(cmd, "/path/to/some/image")
+			restore := main.MockOsArgs(cmd)
+			defer restore()
+
+			err := main.Run()
+			require.EqualError(t, err, tc.expectedErr)
+		})
+	}
+}
+
+var fakeOsbuildScriptAmiFmt = `#!/bin/sh -e
+cat - > "$0".stdin
+mkdir -p %[1]s/ami
+echo -n %[2]s > %[1]s/ami/image.raw
+`
+
+func TestBuildAndUploadWithAWSMock(t *testing.T) {
+	if testing.Short() {
+		t.Skip("manifest generation takes a while")
+	}
+	if !hasDepsolveDnf() {
+		t.Skip("no osbuild-depsolve-dnf binary found")
+	}
+
+	var regionName, bucketName, amiName string
+	var fa fakeAwsUploader
+	restore := main.MockAwscloudNewUploader(func(region string, bucket string, ami string, opts *awscloud.UploaderOptions) (cloud.Uploader, error) {
+		regionName = region
+		bucketName = bucket
+		amiName = ami
+		return &fa, nil
+	})
+	defer restore()
+
+	fakeDiskContent := "fake-raw-img"
+	outputDir := t.TempDir()
+	fakeOsbuildScript := fmt.Sprintf(fakeOsbuildScriptAmiFmt, outputDir, fakeDiskContent)
+	fakeOsbuildCmd := testutil.MockCommand(t, "osbuild", fakeOsbuildScript)
+	defer fakeOsbuildCmd.Restore()
+
+	var fakeStdout bytes.Buffer
+	restore = main.MockOsStdout(&fakeStdout)
+	defer restore()
+
+	restore = main.MockOsArgs([]string{
+		"build",
+		"--output-dir", outputDir,
+		"--aws-region=aws-region-1",
+		"--aws-bucket=aws-bucket-2",
+		"--aws-ami-name=aws-ami-3",
+		"ami",
+		"--distro=centos-9",
+	})
+	defer restore()
+
+	err := main.Run()
+	require.NoError(t, err)
+
+	assert.Equal(t, regionName, "aws-region-1")
+	assert.Equal(t, bucketName, "aws-bucket-2")
+	assert.Equal(t, amiName, "aws-ami-3")
+	assert.Equal(t, 1, fa.checkCalls)
+	assert.Equal(t, 1, fa.uploadAndRegisterCalls)
+	assert.Equal(t, fakeDiskContent, fa.uploadAndRegisterRead.String())
+}
+
+func TestBuildAmiButNotUpload(t *testing.T) {
+	if testing.Short() {
+		t.Skip("manifest generation takes a while")
+	}
+	if !hasDepsolveDnf() {
+		t.Skip("no osbuild-depsolve-dnf binary found")
+	}
+
+	fa := fakeAwsUploader{
+		uploadAndRegisterErr: fmt.Errorf("upload should not be called"),
+	}
+	restore := main.MockAwscloudNewUploader(func(region string, bucket string, ami string, opts *awscloud.UploaderOptions) (cloud.Uploader, error) {
+		return &fa, nil
+	})
+	defer restore()
+
+	fakeDiskContent := "fake-raw-img"
+	outputDir := t.TempDir()
+	fakeOsbuildScript := fmt.Sprintf(fakeOsbuildScriptAmiFmt, outputDir, fakeDiskContent)
+	fakeOsbuildCmd := testutil.MockCommand(t, "osbuild", fakeOsbuildScript)
+	defer fakeOsbuildCmd.Restore()
+
+	var fakeStdout bytes.Buffer
+	restore = main.MockOsStdout(&fakeStdout)
+	defer restore()
+
+	restore = main.MockOsArgs([]string{
+		"build",
+		"--output-dir", outputDir,
+		"ami",
+		"--distro=centos-9",
+	})
+	defer restore()
+
+	err := main.Run()
+	require.NoError(t, err)
+
+	assert.Equal(t, 0, fa.uploadAndRegisterCalls)
+}
+
+func TestBuildAndUploadWithAWSPartialCmdlineErrors(t *testing.T) {
+	if testing.Short() {
+		t.Skip("manifest generation takes a while")
+	}
+	if !hasDepsolveDnf() {
+		t.Skip("no osbuild-depsolve-dnf binary found")
+	}
+
+	fakeDiskContent := "fake-raw-img"
+	outputDir := t.TempDir()
+	fakeOsbuildScript := fmt.Sprintf(fakeOsbuildScriptAmiFmt, outputDir, fakeDiskContent)
+	fakeOsbuildCmd := testutil.MockCommand(t, "osbuild", fakeOsbuildScript)
+	defer fakeOsbuildCmd.Restore()
+
+	restore := main.MockOsArgs([]string{
+		"build",
+		"--output-dir", outputDir,
+		// note that --aws-{ami-name,bucket} is missing
+		"--aws-region=aws-region-1",
+		"ami",
+		"--distro=centos-9",
+	})
+	defer restore()
+
+	err := main.Run()
+	assert.EqualError(t, err, `partial upload config provided: missing upload configuration: ["--aws-ami-name" "--aws-bucket"]`)
+}

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ go 1.22.6
 
 require (
 	github.com/BurntSushi/toml v1.4.0
+	github.com/cheggaaa/pb/v3 v3.1.6
 	github.com/gobwas/glob v0.2.3
 	github.com/osbuild/bootc-image-builder/bib v0.0.0-20250205182004-b35eaa8a3a91
 	github.com/osbuild/images v0.116.0
@@ -22,7 +23,7 @@ require (
 	github.com/VividCortex/ewma v1.2.0 // indirect
 	github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d // indirect
 	github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2 // indirect
-	github.com/cheggaaa/pb/v3 v3.1.6 // indirect
+	github.com/aws/aws-sdk-go v1.55.6 // indirect
 	github.com/containerd/cgroups/v3 v3.0.3 // indirect
 	github.com/containerd/errdefs v0.3.0 // indirect
 	github.com/containerd/errdefs/pkg v0.3.0 // indirect
@@ -68,6 +69,7 @@ require (
 	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/hashicorp/go-version v1.7.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
+	github.com/jmespath/go-jmespath v0.4.0 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/klauspost/compress v1.17.11 // indirect

--- a/go.sum
+++ b/go.sum
@@ -18,6 +18,8 @@ github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d h1:licZJFw2RwpH
 github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d/go.mod h1:asat636LX7Bqt5lYEZ27JNDcqxfjdBQuJ/MM4CN/Lzo=
 github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2 h1:DklsrG3dyBCFEj5IhUbnKptjxatkF07cF2ak3yi77so=
 github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2/go.mod h1:WaHUgvxTVq04UNunO+XhnAqY/wQc+bxr74GqbsZ/Jqw=
+github.com/aws/aws-sdk-go v1.55.6 h1:cSg4pvZ3m8dgYcgqB97MrcdjUmZ1BeMYKUxMMB89IPk=
+github.com/aws/aws-sdk-go v1.55.6/go.mod h1:eRwEWoyTWFMVYVQzKMNHWP5/RV4xIUGMQfXQHfHkpNU=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/cenkalti/backoff/v4 v4.3.0 h1:MyRJ/UdXutAwSAT+s3wNd7MfTIcy71VQueUuFK343L8=
@@ -163,6 +165,10 @@ github.com/hashicorp/go-version v1.7.0 h1:5tqGy27NaOTB8yJKUZELlFAS/LTKJkrmONwQKe
 github.com/hashicorp/go-version v1.7.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
+github.com/jmespath/go-jmespath v0.4.0 h1:BEgLn5cpjn8UN1mAw4NjwDrS35OdebyEtFe+9YPoQUg=
+github.com/jmespath/go-jmespath v0.4.0/go.mod h1:T8mJZnbsbmF+m6zOOFylbeCJqk5+pHWvzYPziyZiYoo=
+github.com/jmespath/go-jmespath/internal/testify v1.5.1 h1:shLQSRRSCCPj3f2gpwzGwWFoC7ycTf1rcQZHOlsJ6N8=
+github.com/jmespath/go-jmespath/internal/testify v1.5.1/go.mod h1:L3OGu8Wl2/fWfCI6z80xFu9LTZmf1ZRjMHUOPmWr69U=
 github.com/jmhodges/clock v1.2.0 h1:eq4kys+NI0PLngzaHEe7AmPT90XMGIEySD1JfV1PDIs=
 github.com/jmhodges/clock v1.2.0/go.mod h1:qKjhA7x7u/lQpPB1XAqX1b1lCI/w3/fNuYpI/ZjLynI=
 github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8HmY=
@@ -425,6 +431,9 @@ gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntN
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=
 gopkg.in/ini.v1 v1.67.0 h1:Dgnx+6+nfE+IfzjUEISNeydPJh9AXNNsWbGP9KzCsOA=
 gopkg.in/ini.v1 v1.67.0/go.mod h1:pNLf8WUiyNEtQjuu5G5vTm06TEv9tsIgeAvK8hOrP4k=
+gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
+gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=


### PR DESCRIPTION
[edit: one open question is if this PR should also contain a variant of this like `build --uplload-to` so that build/upload can be done in a single call.

This commit adds a new `upload` command that can be used to upload a raw image to the cloud. Currently only AWS is supported but as images adds more clouds to the uploader interfac we can trivially expand more.

Note that this needs https://github.com/osbuild/images/pull/1185