### PR TITLE
main: fix auto-detected distro that is non-visible, tweak order

### DIFF
--- a/cmd/image-builder/main.go
+++ b/cmd/image-builder/main.go
@@ -112,10 +112,6 @@ func cmdManifestWrapper(pbar progress.ProgressBar, cmd *cobra.Command, args []st
 		return nil, err
 	}
 
-	imgTypeStr := args[0]
-	pbar.SetPulseMsgf("Manifest generation step")
-	pbar.SetMessagef("Building manifest for %s-%s", imgTypeStr, distroStr)
-
 	bp, err := blueprintload.Load(blueprintPath)
 	if err != nil {
 		return nil, err
@@ -125,6 +121,9 @@ func cmdManifestWrapper(pbar progress.ProgressBar, cmd *cobra.Command, args []st
 	if err != nil {
 		return nil, err
 	}
+	imgTypeStr := args[0]
+	pbar.SetPulseMsgf("Manifest generation step")
+	pbar.SetMessagef("Building manifest for %s-%s", distroStr, imgTypeStr)
 
 	img, err := getOneImage(dataDir, distroStr, imgTypeStr, archStr)
 	if err != nil {


### PR DESCRIPTION
This commit fixes the issue that the auto-detect distro is not visible in the progress message. It also tweaks the order of the message to show:
```
Building manifest for <distro>-<img-type>
```
to be more conistent.

Closes: https://github.com/osbuild/image-builder-cli/issues/121

Note that there is a small tweak needed in the progress library, then this can be properly tested:
```go
func TestManifestIntegrationAutodetectDistro(t *testing.T) {
	if testing.Short() {
		t.Skip("manifest generation takes a while")
	}
	if !hasDepsolveDnf() {
		t.Skip("no osbuild-depsolve-dnf binary found")
	}

	restore := main.MockNewRepoRegistry(testrepos.New)
	defer restore()

	script := `cat - > "$0".stdin`
	fakeOsbuildCmd := testutil.MockCommand(t, "osbuild", script)
	defer fakeOsbuildCmd.Restore()

	restore = main.MockDistroGetHostDistroName(func() (string, error) {
		return "centos-9", nil
	})
	defer restore()

	restore = main.MockOsArgs([]string{
		"build",
		"qcow2",
		"--arch=x86_64",
		"--progress=debug",
	})
	defer restore()

	var fakeStdout bytes.Buffer
	restore = main.MockOsStdout(&fakeStdout)
	defer restore()

	var err error
	_, stderr := testutil.CaptureStdio(t, func() {
		err = main.Run()
	})
	assert.NoError(t, err)
	assert.Contains(t, stderr, "msg: Building manifest for centos-9-qcow2")
}

```
