### PR TITLE
main: reset the terminal properly on SIGINT

### DIFF
--- a/cmd/image-builder/main.go
+++ b/cmd/image-builder/main.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"os/signal"
+	"syscall"
 
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -180,6 +182,12 @@ func cmdBuild(cmd *cobra.Command, args []string) error {
 	}
 	pbar.Start()
 	defer pbar.Stop()
+	go func() {
+		c := make(chan os.Signal, 1)
+		signal.Notify(c, os.Interrupt, syscall.SIGTERM)
+		<-c
+		pbar.Stop()
+	}()
 
 	var mf bytes.Buffer
 	// XXX: check env here, i.e. if user is root and osbuild is installed


### PR DESCRIPTION
This commit fixes the issue that on `CTRL-C` (SIGINT) the progress is not properly cleared.

No test right now as this is hard to test automatically :/

Closes: https://github.com/osbuild/image-builder-cli/issues/123