### PR TITLE
go.mod: update to get the latest `progress` fixes from `bib`

### DIFF
--- a/cmd/image-builder/main_test.go
+++ b/cmd/image-builder/main_test.go
@@ -439,6 +439,8 @@ var failingOsbuild = `
 cat - > "$0".stdin
 echo "error on stdout"
 >&2 echo "error on stderr"
+
+>&3 echo '{"message": "osbuild-stage-output"}'
 exit 1
 `
 
@@ -501,6 +503,8 @@ func TestBuildIntegrationErrorsProgressTerm(t *testing.T) {
 		err = main.Run()
 	})
 	assert.EqualError(t, err, `error running osbuild: exit status 1
+BuildLog:
+osbuild-stage-output
 Output:
 error on stdout
 error on stderr

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ toolchain go1.22.2
 require (
 	github.com/BurntSushi/toml v1.4.0
 	github.com/gobwas/glob v0.2.3
-	github.com/osbuild/bootc-image-builder/bib v0.0.0-20250128074618-f6403409fc97
+	github.com/osbuild/bootc-image-builder/bib v0.0.0-20250205182004-b35eaa8a3a91
 	github.com/osbuild/images v0.112.0
 	github.com/sirupsen/logrus v1.9.3
 	github.com/spf13/cobra v1.8.1

--- a/go.sum
+++ b/go.sum
@@ -222,6 +222,8 @@ github.com/osbuild/bootc-image-builder/bib v0.0.0-20250125114430-c5d674173ba0 h1
 github.com/osbuild/bootc-image-builder/bib v0.0.0-20250125114430-c5d674173ba0/go.mod h1:22erXOiwfznPLNE5Y8hp35fnE0vh5ZjWp/iIQsVnYTg=
 github.com/osbuild/bootc-image-builder/bib v0.0.0-20250128074618-f6403409fc97 h1:Xyv+vDEGCcG1qkHkdQFPBXhvM5WiMiAJm/AjBkzW4Sw=
 github.com/osbuild/bootc-image-builder/bib v0.0.0-20250128074618-f6403409fc97/go.mod h1:22erXOiwfznPLNE5Y8hp35fnE0vh5ZjWp/iIQsVnYTg=
+github.com/osbuild/bootc-image-builder/bib v0.0.0-20250205182004-b35eaa8a3a91 h1:80EI+8V4tOv+sMygoTP8YY+4IIkw1axuuvRHvz7S9HQ=
+github.com/osbuild/bootc-image-builder/bib v0.0.0-20250205182004-b35eaa8a3a91/go.mod h1:22erXOiwfznPLNE5Y8hp35fnE0vh5ZjWp/iIQsVnYTg=
 github.com/osbuild/images v0.112.0 h1:+pKwPniwYTRRgist6V+7DQfZEg7osddl1z4pASecq4M=
 github.com/osbuild/images v0.112.0/go.mod h1:58tzp7jV50rjaH9gMpvmQdVati0c4TaC5Op7wmSD/tY=
 github.com/ostreedev/ostree-go v0.0.0-20210805093236-719684c64e4f h1:/UDgs8FGMqwnHagNDPGOlts35QkhAZ8by3DR7nMih7M=


### PR DESCRIPTION
This commit updates the `progress` package to get the latest fixes, most notably
https://github.com/osbuild/bootc-image-builder/pull/820