### PR TITLE
describeimg: typo in describe output

### DIFF
--- a/cmd/image-builder/describeimg.go
+++ b/cmd/image-builder/describeimg.go
@@ -22,7 +22,7 @@ type describeImgYAML struct {
 	Arch   string `yaml:"arch"`
 
 	// XXX: think about ordering (as this is what the user will see)
-	OsVersion string `yaml:"os_vesion"`
+	OsVersion string `yaml:"os_version"`
 
 	Bootmode        string `yaml:"bootmode"`
 	PartitionType   string `yaml:"partition_type"`

--- a/cmd/image-builder/describeimg_test.go
+++ b/cmd/image-builder/describeimg_test.go
@@ -26,7 +26,7 @@ func TestDescribeImage(t *testing.T) {
 distro: centos-9
 type: tar
 arch: x86_64
-os_vesion: 9-stream
+os_version: 9-stream
 bootmode: none
 partition_type: ""
 default_filename: root.tar.xz


### PR DESCRIPTION
`os_vesion` -> `os_version`