### PR TITLE
main: simplify upload error handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ release_artifacts
 *.swp
 dictionary.dic
 __pycache__
+/bin

--- a/cmd/image-builder/main.go
+++ b/cmd/image-builder/main.go
@@ -232,14 +232,13 @@ func cmdBuild(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	var uploadUnsupported *UploadTypeUnsupportedError
-	var missingUploadConfig *MissingUploadConfigError
 	uploader, err := uploaderFor(cmd, res.ImgType.Name())
-	if err != nil && !errors.As(err, &missingUploadConfig) && !errors.As(err, &uploadUnsupported) {
-		return err
+	if errors.Is(err, ErrUploadTypeUnsupported) || errors.Is(err, ErrUploadConfigNotProvided) {
+		err = nil
 	}
-	if missingUploadConfig != nil && !missingUploadConfig.allMissing {
-		return fmt.Errorf("partial upload config provided: %w", err)
+
+	if err != nil {
+		return err
 	}
 
 	if uploader != nil {

--- a/cmd/image-builder/main_test.go
+++ b/cmd/image-builder/main_test.go
@@ -343,7 +343,7 @@ func TestBuildIntegrationHappy(t *testing.T) {
 	assert.NoError(t, err)
 
 	// ensure osbuild was run exactly one
-	assert.Equal(t, 1, len(fakeOsbuildCmd.Calls()))
+	require.Equal(t, 1, len(fakeOsbuildCmd.Calls()))
 	osbuildCall := fakeOsbuildCmd.Calls()[0]
 	// --cache is passed correctly to osbuild
 	storePos := slices.Index(osbuildCall, "--store")

--- a/cmd/image-builder/upload_test.go
+++ b/cmd/image-builder/upload_test.go
@@ -98,7 +98,7 @@ func TestUploadCmdlineErrors(t *testing.T) {
 			`missing --to parameter, try --to=aws`,
 		}, {
 			[]string{"--to=aws"},
-			`missing upload configuration: ["--aws-ami-name" "--aws-bucket" "--aws-region"]`,
+			`missing all upload configuration: ["--aws-ami-name" "--aws-bucket" "--aws-region"]`,
 		},
 		{
 			[]string{"--to=aws", "--aws-ami-name=1"},
@@ -242,5 +242,5 @@ func TestBuildAndUploadWithAWSPartialCmdlineErrors(t *testing.T) {
 	defer restore()
 
 	err := main.Run()
-	assert.EqualError(t, err, `partial upload config provided: missing upload configuration: ["--aws-ami-name" "--aws-bucket"]`)
+	assert.EqualError(t, err, `missing upload configuration: ["--aws-ami-name" "--aws-bucket"]`)
 }


### PR DESCRIPTION
I do not understand what was a point of the error types in the first place when the handling code would just print them. Since strings works great as error values most of the time in Go, it is such easier and cleaner to simply format them correctly when they occur, having them wrapped and let them to bubble up the stack to print them.

This patch fixes that and simplifies the handling code - just return (thus print) any error that occurs, there is no need to do special handling as long as they are correctly formatted and Go error wrapping encourages exactly that.

Additionally, in another commit I am adding `bin/` to the `.gitignore`.