### PR TITLE
main: add add `--force-repo` flag

### DIFF
--- a/.spellcheck-en-custom.txt
+++ b/.spellcheck-en-custom.txt
@@ -3,6 +3,7 @@ backend
 bootc
 bootmode
 buildable
+centos
 Changelog
 cli
 distro
@@ -33,3 +34,5 @@ amongst
 RHEL
 hyperscalers
 weldr
+libc
+url

--- a/README.md
+++ b/README.md
@@ -189,6 +189,55 @@ $ image-builder list-images --output=json
 ]
 ```
 
+## Modifying the set of used repositories
+
+There are various ways to add extra repositories or override the default
+base repositories. Most users will want to use the
+[blueprint systems](https://osbuild.org/docs/user-guide/blueprint-reference/#repositories)
+for this. Repositories that are part of the blueprint will get added
+to the installed image but are not used at build time to install third-party
+packages.
+
+To change repositories during image build time the command line options
+`--datadir`, `--extra-repo` and `--force-repo` can be used. The repositories
+there will only added during build time and will not be available in the
+installed system (use the above blueprint options if that the goal).
+
+Note that both options are targeting advanced users/use-cases and when
+used wrongly can result in failing image builds or non-booting
+systems.
+
+## Using the datadir switch
+
+When using the `--datadir` flag `image-builder` will look into
+the <datadir>/repositories directory for a file called <distro>.json
+that contains the repositories for the <distro>.
+
+This <distro>.json file is a simple architecture-> repositories mapping
+that looks like [this example](https://github.com/osbuild/images/blob/main/data/repositories/centos-10.json).
+
+### Adding extra repositories during the build
+
+To add one or more extra repositories during the build use:
+`--extra-repo <baseurl>`, e.g. `--extra-repo file:///path/to/repo`.
+This will make the content of the repository available during image
+building and the dependency solver will pick packages from there as
+appropriate (e.g. if that repository contains a libc or kernel with a
+higher version number it will be picked over the default
+repositories).
+
+### Overriding the default base repositories during build
+
+To completely replace the default base repositories during a build the
+option `--force-repo=file:///path/to/repos` can be used.
+
+Note that the repositories defined there will be used for all
+dependency solving and there is no safeguards, i.e. one can point to
+a fedora-42 repository url and try to build a centos-9 image type and
+the system will happily try its best (and most likely fail). Use with
+caution.
+
+
 ## FAQ
 
 Q: Does this require a backend.

--- a/cmd/image-builder/filters.go
+++ b/cmd/image-builder/filters.go
@@ -21,8 +21,14 @@ func newImageFilterDefault(dataDir string, extraRepos []string) (*imagefilter.Im
 }
 
 type repoOptions struct {
-	DataDir    string
+	// DataDir contains the base dir for the repo definition search path
+	DataDir string
+
+	// ExtraRepos contains extra baseURLs that get added to the depsolving
 	ExtraRepos []string
+
+	// ForceRepos contains baseURLs that replace *all* base repositories
+	ForceRepos []string
 }
 
 // should this be moved to images:imagefilter?

--- a/cmd/image-builder/main.go
+++ b/cmd/image-builder/main.go
@@ -87,6 +87,10 @@ func cmdManifestWrapper(pbar progress.ProgressBar, cmd *cobra.Command, args []st
 	if err != nil {
 		return nil, err
 	}
+	forceRepos, err := cmd.Flags().GetStringArray("force-repo")
+	if err != nil {
+		return nil, err
+	}
 	archStr, err := cmd.Flags().GetString("arch")
 	if err != nil {
 		return nil, err
@@ -140,6 +144,7 @@ func cmdManifestWrapper(pbar progress.ProgressBar, cmd *cobra.Command, args []st
 	repoOpts := &repoOptions{
 		DataDir:    dataDir,
 		ExtraRepos: extraRepos,
+		ForceRepos: forceRepos,
 	}
 	img, err := getOneImage(distroStr, imgTypeStr, archStr, repoOpts)
 	if err != nil {
@@ -157,6 +162,8 @@ func cmdManifestWrapper(pbar progress.ProgressBar, cmd *cobra.Command, args []st
 		Ostree:        ostreeImgOpts,
 		RpmDownloader: rpmDownloader,
 		WithSBOM:      withSBOM,
+
+		ForceRepos: forceRepos,
 	}
 	err = generateManifest(dataDir, extraRepos, img, w, opts)
 	return img, err
@@ -317,6 +324,7 @@ operating systems like Fedora, CentOS and RHEL with easy customizations support.
 	}
 	rootCmd.PersistentFlags().String("datadir", "", `Override the default data directory for e.g. custom repositories/*.json data`)
 	rootCmd.PersistentFlags().StringArray("extra-repo", nil, `Add an extra repository during build (will *not* be gpg checked and not be part of the final image)`)
+	rootCmd.PersistentFlags().StringArray("force-repo", nil, `Override the base repositories during build (these will not be part of the final image)`)
 	rootCmd.PersistentFlags().String("output-dir", "", `Put output into the specified directory`)
 	rootCmd.PersistentFlags().BoolP("verbose", "v", false, `Switch to verbose mode`)
 	rootCmd.SetOut(osStdout)

--- a/cmd/image-builder/manifest.go
+++ b/cmd/image-builder/manifest.go
@@ -21,6 +21,8 @@ type manifestOptions struct {
 	Ostree        *ostree.ImageOptions
 	RpmDownloader osbuild.RpmDownloader
 	WithSBOM      bool
+
+	ForceRepos []string
 }
 
 func sbomWriter(outputDir, filename string, content io.Reader) error {
@@ -57,6 +59,13 @@ func generateManifest(dataDir string, extraRepos []string, img *imagefilter.Resu
 		manifestGenOpts.SBOMWriter = func(filename string, content io.Reader, docType sbom.StandardType) error {
 			return sbomWriter(outputDir, filename, content)
 		}
+	}
+	if len(opts.ForceRepos) > 0 {
+		forcedRepos, err := parseRepoURLs(opts.ForceRepos, "forced")
+		if err != nil {
+			return err
+		}
+		manifestGenOpts.OverrideRepos = forcedRepos
 	}
 
 	mg, err := manifestgen.New(repos, manifestGenOpts)

--- a/cmd/image-builder/repos_test.go
+++ b/cmd/image-builder/repos_test.go
@@ -8,16 +8,26 @@ import (
 	"github.com/osbuild/images/pkg/rpmmd"
 )
 
-func TestParseExtraRepoHappy(t *testing.T) {
+func TestParseRepoURLsHappy(t *testing.T) {
 	checkGPG := false
 
-	cfg, err := parseExtraRepo("file:///path/to/repo")
+	cfg, err := parseRepoURLs([]string{
+		"file:///path/to/repo",
+		"https://example.com/repo",
+	}, "forced")
 	assert.NoError(t, err)
 	assert.Equal(t, cfg, []rpmmd.RepoConfig{
 		{
-			Id:           "file:///path/to/repo",
-			Name:         "file:///path/to/repo",
+			Id:           "forced-repo-0",
+			Name:         "forced repo#0 /path/to/repo",
 			BaseURLs:     []string{"file:///path/to/repo"},
+			CheckGPG:     &checkGPG,
+			CheckRepoGPG: &checkGPG,
+		},
+		{
+			Id:           "forced-repo-1",
+			Name:         "forced repo#1 example.com/repo",
+			BaseURLs:     []string{"https://example.com/repo"},
 			CheckGPG:     &checkGPG,
 			CheckRepoGPG: &checkGPG,
 		},
@@ -25,6 +35,9 @@ func TestParseExtraRepoHappy(t *testing.T) {
 }
 
 func TestParseExtraRepoSad(t *testing.T) {
-	_, err := parseExtraRepo("/just/a/path")
-	assert.EqualError(t, err, `scheme missing in "/just/a/path", please prefix with e.g. file:`)
+	_, err := parseRepoURLs([]string{"/just/a/path"}, "forced")
+	assert.EqualError(t, err, `scheme missing in "/just/a/path", please prefix with e.g. file:// or https://`)
+
+	_, err = parseRepoURLs([]string{"https://example.com", "/just/a/path"}, "forced")
+	assert.EqualError(t, err, `scheme missing in "/just/a/path", please prefix with e.g. file:// or https://`)
 }


### PR DESCRIPTION
This commit adds an `--force-repo` flag that can be used
to replace all the base repositories with a base url to
a repository. This is useful for testing but also dangerous
as it will not do any checks and happily use a fedora-42 repository
for centos-8 depsolving.

This will make the use-case of the koji builder easier and is
also something that the `build` tool in `images` supports.
