### PR TITLE
cmd: run simple riscv64 cross build as part of the integration tests

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -13,6 +13,8 @@ RUN CGO_ENABLED=0 go build -tags "containers_image_openpgp exclude_graphdriver_b
 
 FROM registry.fedoraproject.org/fedora:41
 
+# podman mount needs this
+RUN mkdir -p /etc/containers/networks
 # Fast-track osbuild so we don't depend on the "slow" Fedora release process to implement new features in bib
 RUN dnf install -y dnf-plugins-core \
     && dnf copr enable -y @osbuild/osbuild \

--- a/cmd/image-builder/main.go
+++ b/cmd/image-builder/main.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/osbuild/bootc-image-builder/bib/pkg/progress"
 	"github.com/osbuild/images/pkg/arch"
+	"github.com/osbuild/images/pkg/experimentalflags"
 	"github.com/osbuild/images/pkg/imagefilter"
 	"github.com/osbuild/images/pkg/osbuild"
 	"github.com/osbuild/images/pkg/ostree"
@@ -150,7 +151,9 @@ func cmdManifestWrapper(pbar progress.ProgressBar, cmd *cobra.Command, args []st
 	if err != nil {
 		return nil, err
 	}
-	if archChecker != nil {
+	// assume that users with the "bootstrap" flag want cross building
+	// and skip arch checks then
+	if archChecker != nil && experimentalflags.String("bootstrap") == "" {
 		if err := archChecker(img.Arch.Name()); err != nil {
 			return nil, err
 		}

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/cheggaaa/pb/v3 v3.1.7
 	github.com/gobwas/glob v0.2.3
 	github.com/osbuild/bootc-image-builder/bib v0.0.0-20250220151022-a00d61b94388
-	github.com/osbuild/images v0.121.1-0.20250304190605-67d46b671862
+	github.com/osbuild/images v0.122.0
 	github.com/sirupsen/logrus v1.9.3
 	github.com/spf13/cobra v1.9.1
 	github.com/stretchr/testify v1.10.0

--- a/go.sum
+++ b/go.sum
@@ -234,8 +234,8 @@ github.com/opencontainers/selinux v1.11.1 h1:nHFvthhM0qY8/m+vfhJylliSshm8G1jJ2jD
 github.com/opencontainers/selinux v1.11.1/go.mod h1:E5dMC3VPuVvVHDYmi78qvhJp8+M586T4DlDRYpFkyec=
 github.com/osbuild/bootc-image-builder/bib v0.0.0-20250220151022-a00d61b94388 h1:Aft5yg8VLd23dPm3dJcg92+bc3UmxsuSw8WnTm5yGpw=
 github.com/osbuild/bootc-image-builder/bib v0.0.0-20250220151022-a00d61b94388/go.mod h1:mfH19B+cceuQ4PJ6FPsciTtuMFdUiAFHmltgXVg65hg=
-github.com/osbuild/images v0.121.1-0.20250304190605-67d46b671862 h1:6nn3Va7tX2coU4FNIKGeifQx6FP3Jo9jhUUJw/GEOEY=
-github.com/osbuild/images v0.121.1-0.20250304190605-67d46b671862/go.mod h1:Ag87vmyxooiPQBJEDILbypG8/SRIear75YA78NwLix0=
+github.com/osbuild/images v0.122.0 h1:nlCivPpxE7KubNiZV0CMr5M+tAh0lait7RYN7INP17M=
+github.com/osbuild/images v0.122.0/go.mod h1:Ag87vmyxooiPQBJEDILbypG8/SRIear75YA78NwLix0=
 github.com/ostreedev/ostree-go v0.0.0-20210805093236-719684c64e4f h1:/UDgs8FGMqwnHagNDPGOlts35QkhAZ8by3DR7nMih7M=
 github.com/ostreedev/ostree-go v0.0.0-20210805093236-719684c64e4f/go.mod h1:J6OG6YJVEWopen4avK3VNQSnALmmjvniMmni/YFYAwc=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=


### PR DESCRIPTION
This branch shows how to cross arch build traditional images. It also allows to skip
the cross-arch build restriction when `IMAGE_BUILDER_EXPERIMENTAL=bootstrap=...` is set.

The not-so-nice part of this work is that we need to pick the the right container via `IMAGE_BUILDER_EXPERIMENTAL=bootstrap=...`  currently. Fortunately almost any upstream container will do as long as it has rpm and setfiles (policycoreutils).

We really should teach images to map containers to buildroots so that we don't need to do this.

Ideally this would be in "images" itself, I guess we will merge ibcli and images eventually anyway.