### PR TITLE
main: argument names

### DIFF
--- a/.spellcheck-en-custom.txt
+++ b/.spellcheck-en-custom.txt
@@ -14,7 +14,6 @@ json
 osbuild
 qcow
 UEFI
-datadir
 copr
 SBOM
 SBOMs
@@ -36,3 +35,4 @@ hyperscalers
 weldr
 libc
 url
+dir

--- a/README.md
+++ b/README.md
@@ -157,11 +157,11 @@ The following filters are currently supported, shell-style globbing is supported
  * type: the image type name (e.g. qcow2)
  * bootmode: the bootmode (legacy, UEFI, hybrid)
 
-### Output control
+### Text control
 
-The output can also be switched, supported are "text", "json":
+The text format can also be switched, supported are "text", "json":
 ```console
-$ image-builder list-images --output=json
+$ image-builder list-images --format=json
 [
   {
     "distro": {

--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ to the installed image but are not used at build time to install third-party
 packages.
 
 To change repositories during image build time the command line options
-`--datadir`, `--extra-repo` and `--force-repo` can be used. The repositories
+`--data-dir`, `--extra-repo` and `--force-repo` can be used. The repositories
 there will only added during build time and will not be available in the
 installed system (use the above blueprint options if that the goal).
 
@@ -207,9 +207,9 @@ Note that both options are targeting advanced users/use-cases and when
 used wrongly can result in failing image builds or non-booting
 systems.
 
-## Using the datadir switch
+## Using the data-dir switch
 
-When using the `--datadir` flag `image-builder` will look into
+When using the `--data-dir` flag `image-builder` will look into
 the <datadir>/repositories directory for a file called <distro>.json
 that contains the repositories for the <distro>.
 
@@ -246,9 +246,9 @@ A: The osbuild binary is used to actually build the images but beyond that
 
 Q: Can I have custom repository files?
 A: Sure! The repositories are encoded in json in "<distro>-<vesion>.json",
-   files, e.g. "fedora-41.json". See these [examples](https://github.com/osbuild/images/tree/main/data/repositories). Use the "--datadir" switch and
+   files, e.g. "fedora-41.json". See these [examples](https://github.com/osbuild/images/tree/main/data/repositories). Use the "--data-dir" switch and
    place them under "repositories/name-version.json", e.g. for:
-   "--datadir ~/my-project --distro foo-1" a json file must be put under
+   "--data-dir ~/my-project --distro foo-1" a json file must be put under
    "~/my-project/repositories/foo-1.json.
 
 Q: What is the relation to [bootc-image-builder](https://github.com/osbuild/bootc-image-builder)?

--- a/cmd/image-builder/main.go
+++ b/cmd/image-builder/main.go
@@ -41,7 +41,7 @@ func cmdListImages(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	dataDir, err := cmd.Flags().GetString("datadir")
+	dataDir, err := cmd.Flags().GetString("data-dir")
 	if err != nil {
 		return err
 	}
@@ -79,7 +79,7 @@ func ostreeImageOptions(cmd *cobra.Command) (*ostree.ImageOptions, error) {
 }
 
 func cmdManifestWrapper(pbar progress.ProgressBar, cmd *cobra.Command, args []string, w io.Writer, archChecker func(string) error) (*imagefilter.Result, error) {
-	dataDir, err := cmd.Flags().GetString("datadir")
+	dataDir, err := cmd.Flags().GetString("data-dir")
 	if err != nil {
 		return nil, err
 	}
@@ -284,7 +284,7 @@ func cmdBuild(cmd *cobra.Command, args []string) error {
 
 func cmdDescribeImg(cmd *cobra.Command, args []string) error {
 	// XXX: boilderplate identical to cmdManifest() above
-	dataDir, err := cmd.Flags().GetString("datadir")
+	dataDir, err := cmd.Flags().GetString("data-dir")
 	if err != nil {
 		return err
 	}
@@ -327,7 +327,7 @@ Image-builder builds operating system images for a range of predefined
 operating systems like Fedora, CentOS and RHEL with easy customizations support.`,
 		SilenceErrors: true,
 	}
-	rootCmd.PersistentFlags().String("datadir", "", `Override the default data directory for e.g. custom repositories/*.json data`)
+	rootCmd.PersistentFlags().String("data-dir", "", `Override the default data directory for e.g. custom repositories/*.json data`)
 	rootCmd.PersistentFlags().StringArray("extra-repo", nil, `Add an extra repository during build (will *not* be gpg checked and not be part of the final image)`)
 	rootCmd.PersistentFlags().StringArray("force-repo", nil, `Override the base repositories during build (these will not be part of the final image)`)
 	rootCmd.PersistentFlags().String("output-dir", "", `Put output into the specified directory`)

--- a/cmd/image-builder/main.go
+++ b/cmd/image-builder/main.go
@@ -37,7 +37,7 @@ func cmdListImages(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	output, err := cmd.Flags().GetString("output")
+	format, err := cmd.Flags().GetString("format")
 	if err != nil {
 		return err
 	}
@@ -50,7 +50,7 @@ func cmdListImages(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	return listImages(dataDir, extraRepos, output, filter)
+	return listImages(dataDir, extraRepos, format, filter)
 }
 
 func ostreeImageOptions(cmd *cobra.Command) (*ostree.ImageOptions, error) {
@@ -343,7 +343,7 @@ operating systems like Fedora, CentOS and RHEL with easy customizations support.
 		Args:         cobra.NoArgs,
 	}
 	listImagesCmd.Flags().StringArray("filter", nil, `Filter distributions by a specific criteria (e.g. "type:iot*")`)
-	listImagesCmd.Flags().String("output", "", "Output in a specific format (text, json)")
+	listImagesCmd.Flags().String("format", "", "Output in a specific format (text, json)")
 	rootCmd.AddCommand(listImagesCmd)
 
 	manifestCmd := &cobra.Command{

--- a/cmd/image-builder/main_test.go
+++ b/cmd/image-builder/main_test.go
@@ -34,7 +34,7 @@ func TestListImagesNoArguments(t *testing.T) {
 	restore := main.MockNewRepoRegistry(testrepos.New)
 	defer restore()
 
-	for _, args := range [][]string{nil, []string{"--output=text"}} {
+	for _, args := range [][]string{nil, []string{"--format=text"}} {
 		restore = main.MockOsArgs(append([]string{"list-images"}, args...))
 		defer restore()
 
@@ -55,7 +55,7 @@ func TestListImagesNoArgsOutputJSON(t *testing.T) {
 	restore := main.MockNewRepoRegistry(testrepos.New)
 	defer restore()
 
-	restore = main.MockOsArgs([]string{"list-images", "--output=json"})
+	restore = main.MockOsArgs([]string{"list-images", "--format=json"})
 	defer restore()
 
 	var fakeStdout bytes.Buffer


### PR DESCRIPTION
We had a small meeting about the names for our arguments, we want to be consistent so `basedir` is renamed to `base-dir`. `output` gets renamed to `format`.

Tests are updated, so is the README. Did I miss anything?

This PR replaces the exploratory #99.