### PR TITLE
packit: enable epel-9 and epel-10

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -29,14 +29,20 @@ jobs:
     trigger: commit
     dist_git_branches:
       - fedora-branched  # rawhide updates are created automatically
+      - epel-10
+      - epel-9
   - job: koji_build
     trigger: commit
     dist_git_branches:
       - fedora-all
+      - epel-10
+      - epel-9
   - job: propose_downstream
     trigger: release
     dist_git_branches:
       - fedora-all
+      - epel-10
+      - epel-9
   - job: copr_build
     trigger: pull_request
     targets: &build_targets


### PR DESCRIPTION
Let's ship our package in epel-9 and epel-10 as well as all the supported Fedora branches. I've manually created, built, and created updates for these branches already.

I'm not adding automation to the epel-10.0 branch in this PR as we need to probably consider that more carefully. However, I *have* submitted version 13 for epel-10.0 manually.