### PR TITLE
main: fix creating output dir for `--with-buildlog`

### DIFF
--- a/cmd/image-builder/build.go
+++ b/cmd/image-builder/build.go
@@ -37,10 +37,13 @@ func buildImage(pbar progress.ProgressBar, res *imagefilter.Result, osbuildManif
 		OutputDir: opts.OutputDir,
 	}
 	if opts.WriteBuildlog {
+		if err := os.MkdirAll(opts.OutputDir, 0755); err != nil {
+			return fmt.Errorf("cannot create buildlog base directory: %w", err)
+		}
 		p := filepath.Join(opts.OutputDir, fmt.Sprintf("%s.buildlog", outputNameFor(res)))
 		f, err := os.Create(p)
 		if err != nil {
-			return err
+			return fmt.Errorf("cannot create buildlog: %w", err)
 		}
 		defer f.Close()
 

--- a/cmd/image-builder/main_test.go
+++ b/cmd/image-builder/main_test.go
@@ -401,7 +401,7 @@ func TestBuildIntegrationArgs(t *testing.T) {
 		},
 	} {
 		t.Run(strings.Join(tc.args, ","), func(t *testing.T) {
-			outputDir := t.TempDir()
+			outputDir := filepath.Join(t.TempDir(), "output")
 
 			cmd := []string{
 				"build",


### PR DESCRIPTION
Trivial fix for the missing `mkdir()` call when `--with-buildlog` is specified (and the matching test update).