### PR TITLE
doc/00-installation: Add link to package details

### DIFF
--- a/doc/00-installation.md
+++ b/doc/00-installation.md
@@ -1,6 +1,6 @@
 # Installation
 
-`image-builder` packages are available in [Fedora](https://fedoraproject.org). You can also get a copy from other places listed here. After you have `image-builder` installed take a look at its [usage](./01-usage.md).
+`image-builder` packages are available in [Fedora](https://fedoraproject.org) ([package details](https://packages.fedoraproject.org/pkgs/image-builder/image-builder/)). You can also get a copy from other places listed here. After you have `image-builder` installed take a look at its [usage](./01-usage.md).
 
 ## Fedora
 


### PR DESCRIPTION
There should be a link to the package details, not only the reference to the main fedora page.
Is this link a good choice?