### PR TITLE
main: show "success" message with output dir when build finishes

### DIFF
--- a/cmd/image-builder/main.go
+++ b/cmd/image-builder/main.go
@@ -268,10 +268,11 @@ func cmdBuild(cmd *cobra.Command, args []string) error {
 	if err := buildImage(pbar, res, mf.Bytes(), buildOpts); err != nil {
 		return err
 	}
+	pbar.Stop()
+	fmt.Fprintf(osStdout, "Image build successful, result in %q\n", outputDir)
 
 	if uploader != nil {
 		// XXX: integrate better into the progress, see bib
-		pbar.Stop()
 		imagePath := filepath.Join(outputDir, res.ImgType.Name(), res.ImgType.Filename())
 
 		if err := uploadImageWithProgress(uploader, imagePath); err != nil {

--- a/cmd/image-builder/main_test.go
+++ b/cmd/image-builder/main_test.go
@@ -325,6 +325,10 @@ func TestBuildIntegrationHappy(t *testing.T) {
 	restore := main.MockNewRepoRegistry(testrepos.New)
 	defer restore()
 
+	var fakeStdout bytes.Buffer
+	restore = main.MockOsStdout(&fakeStdout)
+	defer restore()
+
 	tmpdir := t.TempDir()
 	restore = main.MockOsArgs([]string{
 		"build",
@@ -341,6 +345,8 @@ func TestBuildIntegrationHappy(t *testing.T) {
 
 	err := main.Run()
 	assert.NoError(t, err)
+
+	assert.Contains(t, fakeStdout.String(), `Image build successful, result in "centos-9-qcow2-x86_64"`+"\n")
 
 	// ensure osbuild was run exactly one
 	require.Equal(t, 1, len(fakeOsbuildCmd.Calls()))


### PR DESCRIPTION
This commit adds a "success" message that also contains the output dir when the build finishes.

Thanks to SimonS for suggesting this!