### PR TITLE
main: skip arch checks on`IMAGE_BUILDER_EXPERIMENTAL=bootstrap`

### DIFF
--- a/cmd/image-builder/main.go
+++ b/cmd/image-builder/main.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/osbuild/bootc-image-builder/bib/pkg/progress"
 	"github.com/osbuild/images/pkg/arch"
+	"github.com/osbuild/images/pkg/experimentalflags"
 	"github.com/osbuild/images/pkg/imagefilter"
 	"github.com/osbuild/images/pkg/osbuild"
 	"github.com/osbuild/images/pkg/ostree"
@@ -150,7 +151,9 @@ func cmdManifestWrapper(pbar progress.ProgressBar, cmd *cobra.Command, args []st
 	if err != nil {
 		return nil, err
 	}
-	if archChecker != nil {
+	// assume that users with the "bootstrap" flag want cross building
+	// and skip arch checks then
+	if archChecker != nil && experimentalflags.String("bootstrap") == "" {
 		if err := archChecker(img.Arch.Name()); err != nil {
 			return nil, err
 		}

--- a/cmd/image-builder/main_test.go
+++ b/cmd/image-builder/main_test.go
@@ -758,3 +758,43 @@ func TestManifestOverrideRepo(t *testing.T) {
 	// `error depsolving: running osbuild-depsolve-dnf failed:
 	// DNF error occurred: RepoError: There was a problem reading a repository: Failed to download metadata for repo '9828718901ab404ac1b600157aec1a8b19f4b2139e7756f347fb0ecc06c92929' [forced repo#0 xxx.abcdefgh-no-such-host.com/repo: http://xxx.abcdefgh-no-such-host.com/repo]: Cannot download repomd.xml: Cannot download repodata/repomd.xml: All mirrors were tried`
 }
+
+func TestBuildCrossArchCheckSkippedOnExperimentalBuildroot(t *testing.T) {
+	if testing.Short() {
+		t.Skip("manifest generation takes a while")
+	}
+	if !hasDepsolveDnf() {
+		t.Skip("no osbuild-depsolve-dnf binary found")
+	}
+
+	restore := main.MockNewRepoRegistry(testrepos.New)
+	defer restore()
+
+	tmpdir := t.TempDir()
+	for _, withExperimentalBootstrapEnv := range []bool{false, true} {
+		if withExperimentalBootstrapEnv {
+			t.Setenv("IMAGE_BUILDER_EXPERIMENTAL", "bootstrap=ghcr.io/mvo5/fedora-buildroot:41")
+		}
+		restore = main.MockOsArgs([]string{
+			"build",
+			"qcow2",
+			"--distro", "centos-9",
+			"--cache", tmpdir,
+			"--arch=s390x",
+		})
+		defer restore()
+
+		script := `cat - > "$0".stdin`
+		fakeOsbuildCmd := testutil.MockCommand(t, "osbuild", script)
+		defer fakeOsbuildCmd.Restore()
+
+		err := main.Run()
+		if withExperimentalBootstrapEnv {
+			assert.NoError(t, err)
+			require.Equal(t, 1, len(fakeOsbuildCmd.Calls()))
+		} else {
+			assert.EqualError(t, err, `cannot build for arch "s390x" from "x86_64"`)
+			require.Equal(t, 0, len(fakeOsbuildCmd.Calls()))
+		}
+	}
+}


### PR DESCRIPTION
This commit skips the arch checks if the experimental "bootstrap" option is used. The main use-case of this option is to bootstrap a foreign architecture so just assume that and skip arch checks when set.

This allows to write:
```
$ IMAGE_BUILDER_EXPERIMENTAL=bootstrap=ghcr.io/mvo5/fedora-buildroot:41 \
   ./image-builder build --arch=riscv64 minimal-raw --distro=fedora-41
```
and do a riscv64 cross arch build.

[split our from https://github.com/osbuild/image-builder-cli/pull/136 to make cross-build workable]