### PR TITLE
tools: provide a `run-in-mock` helper for the koji-plugin

### DIFF
--- a/image-builder.spec
+++ b/image-builder.spec
@@ -90,6 +90,8 @@ GOTAGS="exclude_graphdriver_btrfs"
 %install
 install -m 0755 -vd                                 %{buildroot}%{_bindir}
 install -m 0755 -vp %{gobuilddir}/bin/image-builder %{buildroot}%{_bindir}/
+install -m 0755 -vd                                 %{buildroot}%{_datadir}/image-builder/tools
+install -m 0755 -vp ./tools/run-in-mock             %{buildroot}%{_libexecdir}/image-builder/tools
 
 %check
 export GOFLAGS="-buildmode=pie"

--- a/tools/run-in-mock
+++ b/tools/run-in-mock
@@ -1,0 +1,35 @@
+#!/bin/bash
+#
+# taken from https://gist.github.com/jlebon/fb6e7c6dcc3ce17d3e2a86f5938ec033
+# and very lightly tweaked
+set -euo pipefail
+
+# This is a small compatibility script that ensures mock
+# chroots are compatible with applications that expect / to
+# be a mount point, such as bubblewrap.
+
+NEW_ROOT=$(mktemp -d mock-compat-root-XXXXXX)
+
+cleanup() {
+    for mnt in sys proc dev; do
+        umount "$NEW_ROOT"/$mnt
+    done
+    umount "$NEW_ROOT"
+    umount "$NEW_ROOT"
+}
+
+trap cleanup EXIT
+
+# The parent of mount in which we'll chroot can't be shared
+# or pivot_root will barf. So we just remount onto itself,
+# but make sure to make the first parent mount private.
+
+mkdir -p "$NEW_ROOT"
+mount --bind / "$NEW_ROOT"
+mount --make-private "$NEW_ROOT"
+mount --bind "$NEW_ROOT" "$NEW_ROOT"
+for mnt in sys proc dev; do
+    mount --bind /$mnt "$NEW_ROOT"/$mnt
+done
+
+chroot "$NEW_ROOT" "$@"


### PR DESCRIPTION
This commit adds a `tools/run-in-mock` script that can be used to wrap running image-builder inside a mock chroot. Without this wrapper bwrap will error because it expects a "/" directory but that is missing in the mock chroots.

Kudos to jlebon and his mock-mount.sh that is available here: https://gist.github.com/jlebon/fb6e7c6dcc3ce17d3e2a86f5938ec033

See also https://github.com/containers/bubblewrap/issues/135

This assume we can just package/run this wrapper from our koji plugin - this is a very simple and straightforward way to solve this, I also did an alternative version that is fully self-contained inside image-builder-cli https://github.com/osbuild/image-builder-cli/compare/main...mvo5:deal-with-mock-self-contained-but-ugly?expand=1 but that contains some tricky (and arguably ugly) re-exec logic that we would only need for this run-in-mock usecase.