### PR TITLE
ibcli: add new --output-name flag and predictable default names

### DIFF
--- a/cmd/image-builder/build.go
+++ b/cmd/image-builder/build.go
@@ -4,31 +4,34 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/osbuild/bootc-image-builder/bib/pkg/progress"
 	"github.com/osbuild/images/pkg/imagefilter"
 )
 
 type buildOptions struct {
-	OutputDir string
-	StoreDir  string
+	OutputDir      string
+	StoreDir       string
+	OutputBasename string
 
 	WriteManifest bool
 	WriteBuildlog bool
 }
 
-func buildImage(pbar progress.ProgressBar, res *imagefilter.Result, osbuildManifest []byte, opts *buildOptions) error {
+func buildImage(pbar progress.ProgressBar, res *imagefilter.Result, osbuildManifest []byte, opts *buildOptions) (string, error) {
 	if opts == nil {
 		opts = &buildOptions{}
 	}
 
+	basename := basenameFor(res, opts.OutputBasename)
 	if opts.WriteManifest {
-		p := filepath.Join(opts.OutputDir, fmt.Sprintf("%s.osbuild-manifest.json", outputNameFor(res)))
+		p := filepath.Join(opts.OutputDir, fmt.Sprintf("%s.osbuild-manifest.json", basename))
 		if err := os.MkdirAll(filepath.Dir(p), 0755); err != nil {
-			return err
+			return "", err
 		}
 		if err := os.WriteFile(p, osbuildManifest, 0644); err != nil {
-			return err
+			return "", err
 		}
 	}
 
@@ -38,16 +41,32 @@ func buildImage(pbar progress.ProgressBar, res *imagefilter.Result, osbuildManif
 	}
 	if opts.WriteBuildlog {
 		if err := os.MkdirAll(opts.OutputDir, 0755); err != nil {
-			return fmt.Errorf("cannot create buildlog base directory: %w", err)
+			return "", fmt.Errorf("cannot create buildlog base directory: %w", err)
 		}
-		p := filepath.Join(opts.OutputDir, fmt.Sprintf("%s.buildlog", outputNameFor(res)))
+		p := filepath.Join(opts.OutputDir, fmt.Sprintf("%s.buildlog", basename))
 		f, err := os.Create(p)
 		if err != nil {
-			return fmt.Errorf("cannot create buildlog: %w", err)
+			return "", fmt.Errorf("cannot create buildlog: %w", err)
 		}
 		defer f.Close()
 
 		osbuildOpts.BuildLog = f
 	}
-	return progress.RunOSBuild(pbar, osbuildManifest, res.ImgType.Exports(), osbuildOpts)
+	if err := progress.RunOSBuild(pbar, osbuildManifest, res.ImgType.Exports(), osbuildOpts); err != nil {
+		return "", err
+	}
+	// Rename *sigh*, see https://github.com/osbuild/images/pull/1039
+	// for my preferred way. Every frontend to images has to duplicate
+	// similar code like this.
+	pipelineDir := filepath.Join(opts.OutputDir, res.ImgType.Exports()[0])
+	srcName := filepath.Join(pipelineDir, res.ImgType.Filename())
+	imgExt := strings.SplitN(res.ImgType.Filename(), ".", 2)[1]
+	dstName := filepath.Join(opts.OutputDir, fmt.Sprintf("%s.%v", basename, imgExt))
+	if err := os.Rename(srcName, dstName); err != nil {
+		return "", fmt.Errorf("cannot rename artifact to final name: %w", err)
+	}
+	// best effort, remove the now empty pipeline export dir from osbuild
+	_ = os.Remove(pipelineDir)
+
+	return dstName, nil
 }

--- a/cmd/image-builder/main_test.go
+++ b/cmd/image-builder/main_test.go
@@ -879,7 +879,7 @@ func TestBuildIntegrationOutputFilename(t *testing.T) {
 		"--distro", "centos-9",
 		"--cache", tmpdir,
 		"--output-dir", outputDir,
-		"--output-name=foo",
+		"--output-name=foo.n.0",
 		"--with-manifest",
 		"--with-sbom",
 		"--with-buildlog",
@@ -894,11 +894,11 @@ func TestBuildIntegrationOutputFilename(t *testing.T) {
 	assert.NoError(t, err)
 
 	expectedFiles := []string{
-		"foo.buildroot-build.spdx.json",
-		"foo.image-os.spdx.json",
-		"foo.osbuild-manifest.json",
-		"foo.buildlog",
-		"foo.qcow2",
+		"foo.n.0.buildroot-build.spdx.json",
+		"foo.n.0.image-os.spdx.json",
+		"foo.n.0.osbuild-manifest.json",
+		"foo.n.0.buildlog",
+		"foo.n.0.qcow2",
 	}
 	files, err := filepath.Glob(outputDir + "/*")
 	assert.NoError(t, err)

--- a/cmd/image-builder/manifest.go
+++ b/cmd/image-builder/manifest.go
@@ -56,10 +56,9 @@ func generateManifest(dataDir string, extraRepos []string, img *imagefilter.Resu
 	}
 	if opts.WithSBOM {
 		outputDir := basenameFor(img, opts.OutputDir)
-		overrideSBOMBase := strings.SplitN(opts.OutputFilename, ".", 2)[0]
 		manifestGenOpts.SBOMWriter = func(filename string, content io.Reader, docType sbom.StandardType) error {
-			if overrideSBOMBase != "" {
-				filename = fmt.Sprintf("%s.%s", overrideSBOMBase, strings.SplitN(filename, ".", 2)[1])
+			if opts.OutputFilename != "" {
+				filename = fmt.Sprintf("%s.%s", opts.OutputFilename, strings.SplitN(filename, ".", 2)[1])
 			}
 			return sbomWriter(outputDir, filename, content)
 		}

--- a/cmd/image-builder/upload_test.go
+++ b/cmd/image-builder/upload_test.go
@@ -121,12 +121,6 @@ func TestUploadCmdlineErrors(t *testing.T) {
 	}
 }
 
-var fakeOsbuildScriptAmiFmt = `#!/bin/sh -e
-cat - > "$0".stdin
-mkdir -p %[1]s/ami
-echo -n %[2]s > %[1]s/ami/image.raw
-`
-
 func TestBuildAndUploadWithAWSMock(t *testing.T) {
 	if testing.Short() {
 		t.Skip("manifest generation takes a while")
@@ -145,9 +139,8 @@ func TestBuildAndUploadWithAWSMock(t *testing.T) {
 	})
 	defer restore()
 
-	fakeDiskContent := "fake-raw-img"
 	outputDir := t.TempDir()
-	fakeOsbuildScript := fmt.Sprintf(fakeOsbuildScriptAmiFmt, outputDir, fakeDiskContent)
+	fakeOsbuildScript := makeFakeOsbuildScript()
 	fakeOsbuildCmd := testutil.MockCommand(t, "osbuild", fakeOsbuildScript)
 	defer fakeOsbuildCmd.Restore()
 
@@ -174,7 +167,7 @@ func TestBuildAndUploadWithAWSMock(t *testing.T) {
 	assert.Equal(t, amiName, "aws-ami-3")
 	assert.Equal(t, 1, fa.checkCalls)
 	assert.Equal(t, 1, fa.uploadAndRegisterCalls)
-	assert.Equal(t, fakeDiskContent, fa.uploadAndRegisterRead.String())
+	assert.Equal(t, "fake-img-raw\n", fa.uploadAndRegisterRead.String())
 }
 
 func TestBuildAmiButNotUpload(t *testing.T) {
@@ -193,9 +186,8 @@ func TestBuildAmiButNotUpload(t *testing.T) {
 	})
 	defer restore()
 
-	fakeDiskContent := "fake-raw-img"
 	outputDir := t.TempDir()
-	fakeOsbuildScript := fmt.Sprintf(fakeOsbuildScriptAmiFmt, outputDir, fakeDiskContent)
+	fakeOsbuildScript := makeFakeOsbuildScript()
 	fakeOsbuildCmd := testutil.MockCommand(t, "osbuild", fakeOsbuildScript)
 	defer fakeOsbuildCmd.Restore()
 
@@ -225,9 +217,8 @@ func TestBuildAndUploadWithAWSPartialCmdlineErrors(t *testing.T) {
 		t.Skip("no osbuild-depsolve-dnf binary found")
 	}
 
-	fakeDiskContent := "fake-raw-img"
 	outputDir := t.TempDir()
-	fakeOsbuildScript := fmt.Sprintf(fakeOsbuildScriptAmiFmt, outputDir, fakeDiskContent)
+	fakeOsbuildScript := makeFakeOsbuildScript()
 	fakeOsbuildCmd := testutil.MockCommand(t, "osbuild", fakeOsbuildScript)
 	defer fakeOsbuildCmd.Restore()
 

--- a/internal/testutil/testutil.go
+++ b/internal/testutil/testutil.go
@@ -110,3 +110,19 @@ func CaptureStdio(t *testing.T, f func()) (string, string) {
 	wg.Wait()
 	return stdout.String(), stderr.String()
 }
+
+func Chdir(t *testing.T, dir string, f func()) {
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Errorf("%s", err.Error())
+	}
+	defer func() {
+		os.Chdir(cwd)
+	}()
+
+	err = os.Chdir(dir)
+	if err != nil {
+		t.Errorf("%s", err.Error())
+	}
+	f()
+}

--- a/internal/testutil/testutil_test.go
+++ b/internal/testutil/testutil_test.go
@@ -34,3 +34,15 @@ func TestCaptureStdout(t *testing.T) {
 	assert.Equal(t, "output on stdout", stdout)
 	assert.Equal(t, "output on stderr", stderr)
 }
+
+func TestChroot(t *testing.T) {
+	tmpdir := t.TempDir()
+	testutil.Chdir(t, tmpdir, func() {
+		cwd, err := os.Getwd()
+		assert.NoError(t, err)
+		assert.Equal(t, tmpdir, cwd)
+	})
+	cwd, err := os.Getwd()
+	assert.NoError(t, err)
+	assert.NotEqual(t, tmpdir, cwd)
+}

--- a/test/test_container.py
+++ b/test/test_container.py
@@ -22,7 +22,8 @@ def test_container_builds_image(tmp_path, build_container, use_librepo):
         f"--use-librepo={use_librepo}",
     ])
     arch = "x86_64"
-    assert (output_dir / f"centos-9-minimal-raw-{arch}/xz/disk.raw.xz").exists()
+    basename = f"centos-9-minimal-raw-{arch}"
+    assert (output_dir / basename / f"{basename}.raw.xz").exists()
     # XXX: ensure no other leftover dirs
     dents = os.listdir(output_dir)
     assert len(dents) == 1, f"too many dentries in output dir: {dents}"
@@ -88,8 +89,9 @@ def test_container_with_progress(tmp_path, build_fake_container, progress, needl
         "-v", f"{output_dir}:/output",
         build_fake_container,
         "build",
-        "minimal-raw",
+        "qcow2",
         "--distro", "centos-9",
+        "--output-dir=.",
         f"--progress={progress}",
     ], text=True)
     assert needle in output


### PR DESCRIPTION
This commit adds a new `--output-name` flag that will rename the resulting artifact after it was build. All auxillary artifacts like buildlog, sbom etc are also name based on the same basename.

One open question is if this should be "--output-filename" or "--basename".

See also https://github.com/osbuild/images/pull/1039 for how
this could be simpler (especially the fake osbuild).

As a side-effect this will now produce more predictable names by default as well:
```
fedora-42-minimal-raw-zst-x86_64/fedora-42-minimal-raw-zst-x86_64.raw.zst
````