### PR TITLE
main: tweak handling of --output-name to avoid adding double extensions

### DIFF
--- a/cmd/image-builder/export_test.go
+++ b/cmd/image-builder/export_test.go
@@ -16,6 +16,7 @@ var (
 	FindDistro      = findDistro
 	DescribeImage   = describeImage
 	ProgressFromCmd = progressFromCmd
+	BasenameFor     = basenameFor
 )
 
 func MockOsArgs(new []string) (restore func()) {

--- a/cmd/image-builder/main.go
+++ b/cmd/image-builder/main.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/signal"
 	"path/filepath"
+
 	"strings"
 	"syscall"
 
@@ -32,6 +33,18 @@ var (
 // for the given imageType. This can be user overriden via userBasename.
 func basenameFor(img *imagefilter.Result, userBasename string) string {
 	if userBasename != "" {
+		// If the user provided a basename that already has the
+		// image extension just strip that off. I.e. when
+		// we get "foo.qcow2" for a qcow out basename is just
+		// "foo". This is mostly for convenience for our users.
+		//
+		// This code assumes that all our ImgType filesnames have
+		// $name.$ext.$extraExt (e.g. disk.qcow2 or disk.raw.xz)
+		l := strings.SplitN(img.ImgType.Filename(), ".", 2)
+		if len(l) > 1 && l[1] != "" {
+			imgExt := fmt.Sprintf(".%s", l[1])
+			userBasename = strings.TrimSuffix(userBasename, imgExt)
+		}
 		return userBasename
 	}
 	return fmt.Sprintf("%s-%s-%s", img.Distro.Name(), img.ImgType.Name(), img.Arch.Name())

--- a/cmd/image-builder/manifest.go
+++ b/cmd/image-builder/manifest.go
@@ -59,9 +59,7 @@ func generateManifest(dataDir string, extraRepos []string, img *imagefilter.Resu
 	if opts.WithSBOM {
 		outputDir := basenameFor(img, opts.OutputDir)
 		manifestGenOpts.SBOMWriter = func(filename string, content io.Reader, docType sbom.StandardType) error {
-			if opts.OutputFilename != "" {
-				filename = fmt.Sprintf("%s.%s", opts.OutputFilename, strings.SplitN(filename, ".", 2)[1])
-			}
+			filename = fmt.Sprintf("%s.%s", basenameFor(img, opts.OutputFilename), strings.SplitN(filename, ".", 2)[1])
 			return sbomWriter(outputDir, filename, content)
 		}
 	}


### PR DESCRIPTION
This commit tweaks the handling of the `--output-name` option so that is a name with the same extension as the image is passed that is just silently ignored. Its a common issue that first time users run:
```console
$ image-builder build --output-name foo.qcow2 qcow2
```
which currently leads to a `foo.qcow2.qcow2`. 

With this commit the expected "foo.qcow2" will appear.