### PR TITLE
main: show output directory content after image build

### DIFF
--- a/cmd/image-builder/main.go
+++ b/cmd/image-builder/main.go
@@ -7,6 +7,8 @@ import (
 	"io"
 	"os"
 	"os/signal"
+	"path/filepath"
+	"strings"
 	"syscall"
 
 	"github.com/sirupsen/logrus"
@@ -207,6 +209,17 @@ func progressFromCmd(cmd *cobra.Command) (progress.ProgressBar, error) {
 	return progress.New(progressType)
 }
 
+// listOutputdir will return a string with the output dir content.
+// Any errors will also just appear as part of the string (as it is
+// purely informational)
+func listOutputdir(path string) string {
+	ents, err := filepath.Glob(filepath.Join(path, "/*"))
+	if err != nil {
+		return fmt.Sprintf("error: %v", err)
+	}
+	return strings.Join(ents, ",")
+}
+
 func cmdBuild(cmd *cobra.Command, args []string) error {
 	cacheDir, err := cmd.Flags().GetString("cache")
 	if err != nil {
@@ -284,7 +297,8 @@ func cmdBuild(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	pbar.Stop()
-	fmt.Fprintf(osStdout, "Image build successful, result in %q\n", outputDir)
+
+	fmt.Fprintf(osStdout, "Image build successful, results:\n%s\n", listOutputdir(outputDir))
 
 	if uploader != nil {
 		// XXX: integrate better into the progress, see bib

--- a/cmd/image-builder/main_test.go
+++ b/cmd/image-builder/main_test.go
@@ -391,7 +391,9 @@ func TestBuildIntegrationHappy(t *testing.T) {
 	})
 	assert.NoError(t, err)
 
-	assert.Contains(t, fakeStdout.String(), `Image build successful, result in "centos-9-qcow2-x86_64"`+"\n")
+	assert.Contains(t, fakeStdout.String(), `Image build successful, results:
+centos-9-qcow2-x86_64/centos-9-qcow2-x86_64.qcow2
+`)
 
 	// ensure osbuild was run exactly one
 	require.Equal(t, 1, len(fakeOsbuildCmd.Calls()))


### PR DESCRIPTION
This commit adds the content of the output directory when a build is finished. This is a convenient feature to make it easier for the users.

Thanks to Simon for suggesting this!