### PR TITLE
blueprintload: enable strict checking for toml

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ module github.com/osbuild/image-builder-cli
 go 1.22.8
 
 require (
-	github.com/BurntSushi/toml v1.4.0
+	github.com/BurntSushi/toml v1.5.0
 	github.com/cheggaaa/pb/v3 v3.1.7
 	github.com/gobwas/glob v0.2.3
 	github.com/osbuild/bootc-image-builder/bib v0.0.0-20250220151022-a00d61b94388

--- a/go.sum
+++ b/go.sum
@@ -8,6 +8,8 @@ github.com/Azure/go-ansiterm v0.0.0-20230124172434-306776ec8161/go.mod h1:xomTg6
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/toml v1.4.0 h1:kuoIxZQy2WRRk1pttg9asf+WVv6tWQuBNVmK8+nqPr0=
 github.com/BurntSushi/toml v1.4.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
+github.com/BurntSushi/toml v1.5.0 h1:W5quZX/G/csjUnuI8SUYlsHs9M38FC7znL0lIO+DvMg=
+github.com/BurntSushi/toml v1.5.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
 github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
 github.com/Microsoft/hcsshim v0.12.9 h1:2zJy5KA+l0loz1HzEGqyNnjd3fyZA31ZBCGKacp6lLg=

--- a/internal/blueprintload/blueprintload.go
+++ b/internal/blueprintload/blueprintload.go
@@ -17,9 +17,12 @@ func decodeToml(r io.Reader, what string) (*blueprint.Blueprint, error) {
 	dec := toml.NewDecoder(r)
 
 	var conf blueprint.Blueprint
-	_, err := dec.Decode(&conf)
+	metadata, err := dec.Decode(&conf)
 	if err != nil {
 		return nil, fmt.Errorf("cannot decode %q: %w", what, err)
+	}
+	if len(metadata.Undecoded()) > 0 {
+		return nil, fmt.Errorf("cannot decode %q: unknown keys found: %v", what, metadata.Undecoded())
 	}
 
 	return &conf, nil

--- a/internal/blueprintload/blueprintload_test.go
+++ b/internal/blueprintload/blueprintload_test.go
@@ -27,6 +27,17 @@ var testBlueprintTOML = `
 name = "alice"
 `
 
+var testBlueprintJSONunknownKeys = `
+{
+  "birds": {"name": "robin"}
+}
+`
+
+var testBlueprintTOMLunknownKeys = `
+[[birds]]
+name = "robin"
+`
+
 var expectedBlueprint = &blueprint.Blueprint{
 	Customizations: &blueprint.Customizations{
 		User: []blueprint.UserCustomization{
@@ -55,9 +66,11 @@ func TestBlueprintLoadJSON(t *testing.T) {
 	}{
 		{"bp.json", testBlueprintJSON, expectedBlueprint, ""},
 		{"bp.toml", testBlueprintTOML, expectedBlueprint, ""},
-		{"bp.toml", "wrong-content", nil, `cannot decode .*/bp.toml": toml: `},
-		{"bp.json", "wrong-content", nil, `cannot decode .*/bp.json": invalid `},
+		{"bp.toml", "wrong-content", nil, `cannot decode ".*/bp.toml": toml: `},
+		{"bp.json", "wrong-content", nil, `cannot decode ".*/bp.json": invalid `},
 		{"bp", "wrong-content", nil, `unsupported file extension for "/.*/bp"`},
+		{"bp.toml", testBlueprintTOMLunknownKeys, nil, `cannot decode ".*/bp.toml": unknown keys found: \[birds birds.name\]`},
+		{"bp.json", testBlueprintJSONunknownKeys, nil, `cannot decode ".*/bp.json": json: unknown field "birds"`},
 	} {
 		blueprintPath := makeTestBlueprint(t, tc.fname, tc.content)
 		bp, err := blueprintload.Load(blueprintPath)


### PR DESCRIPTION
Add strict checking for toml keys in blueprints. This allows us
to error early if there are unknown keys in a toml blueprint and
helps our users by spotting e.g. typos early.

This is similar to
https://github.com/osbuild/bootc-image-builder/pull/549
(thanks Ondrej!).
