### PR TITLE
main: automatically cross build when --arch <foreign> is passed

### DIFF
--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -34,6 +34,8 @@ jobs:
         run: |
           sudo apt update
           sudo apt install -y python3-pytest golang
+      - name: Install cross build dependencies
+        run: sudo apt install -y qemu-user-static
 
       - name: Run integration tests via pytest
         run: |

--- a/Containerfile
+++ b/Containerfile
@@ -13,6 +13,8 @@ RUN CGO_ENABLED=0 go build -tags "containers_image_openpgp exclude_graphdriver_b
 
 FROM registry.fedoraproject.org/fedora:41
 
+# podman mount needs this
+RUN mkdir -p /etc/containers/networks
 # Fast-track osbuild so we don't depend on the "slow" Fedora release process to implement new features in bib
 RUN dnf install -y dnf-plugins-core \
     && dnf copr enable -y @osbuild/osbuild \

--- a/cmd/image-builder/manifest.go
+++ b/cmd/image-builder/manifest.go
@@ -25,7 +25,8 @@ type manifestOptions struct {
 	RpmDownloader  osbuild.RpmDownloader
 	WithSBOM       bool
 
-	ForceRepos []string
+	ForceRepos            []string
+	UseBootstrapContainer bool
 }
 
 func sbomWriter(outputDir, filename string, content io.Reader) error {
@@ -51,8 +52,9 @@ func generateManifest(dataDir string, extraRepos []string, img *imagefilter.Resu
 	}
 	// XXX: add --rpmmd/cachedir option like bib
 	manifestGenOpts := &manifestgen.Options{
-		Output:        output,
-		RpmDownloader: opts.RpmDownloader,
+		Output:                output,
+		RpmDownloader:         opts.RpmDownloader,
+		UseBootstrapContainer: opts.UseBootstrapContainer,
 	}
 	if opts.WithSBOM {
 		outputDir := basenameFor(img, opts.OutputDir)

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/cheggaaa/pb/v3 v3.1.7
 	github.com/gobwas/glob v0.2.3
 	github.com/osbuild/bootc-image-builder/bib v0.0.0-20250220151022-a00d61b94388
-	github.com/osbuild/images v0.121.1-0.20250304190605-67d46b671862
+	github.com/osbuild/images v0.127.0
 	github.com/sirupsen/logrus v1.9.3
 	github.com/spf13/cobra v1.9.1
 	github.com/stretchr/testify v1.10.0

--- a/go.sum
+++ b/go.sum
@@ -234,8 +234,8 @@ github.com/opencontainers/selinux v1.11.1 h1:nHFvthhM0qY8/m+vfhJylliSshm8G1jJ2jD
 github.com/opencontainers/selinux v1.11.1/go.mod h1:E5dMC3VPuVvVHDYmi78qvhJp8+M586T4DlDRYpFkyec=
 github.com/osbuild/bootc-image-builder/bib v0.0.0-20250220151022-a00d61b94388 h1:Aft5yg8VLd23dPm3dJcg92+bc3UmxsuSw8WnTm5yGpw=
 github.com/osbuild/bootc-image-builder/bib v0.0.0-20250220151022-a00d61b94388/go.mod h1:mfH19B+cceuQ4PJ6FPsciTtuMFdUiAFHmltgXVg65hg=
-github.com/osbuild/images v0.121.1-0.20250304190605-67d46b671862 h1:6nn3Va7tX2coU4FNIKGeifQx6FP3Jo9jhUUJw/GEOEY=
-github.com/osbuild/images v0.121.1-0.20250304190605-67d46b671862/go.mod h1:Ag87vmyxooiPQBJEDILbypG8/SRIear75YA78NwLix0=
+github.com/osbuild/images v0.127.0 h1:O77/Gi4WmBe/YnFveG1U55oe895Lly7nzsYfmwyjqL0=
+github.com/osbuild/images v0.127.0/go.mod h1:Ag87vmyxooiPQBJEDILbypG8/SRIear75YA78NwLix0=
 github.com/ostreedev/ostree-go v0.0.0-20210805093236-719684c64e4f h1:/UDgs8FGMqwnHagNDPGOlts35QkhAZ8by3DR7nMih7M=
 github.com/ostreedev/ostree-go v0.0.0-20210805093236-719684c64e4f/go.mod h1:J6OG6YJVEWopen4avK3VNQSnALmmjvniMmni/YFYAwc=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=

--- a/test/test_container.py
+++ b/test/test_container.py
@@ -96,3 +96,29 @@ def test_container_with_progress(tmp_path, build_fake_container, progress, needl
     ], text=True)
     assert needle in output
     assert forbidden not in output
+
+
+# only test a subset here to avoid overly long runtimes
+@pytest.mark.parametrize("arch", ["aarch64", "ppc64le", "riscv64", "s390x"])
+def test_container_cross_build(tmp_path, build_container, arch):
+    # this is only here to speed up builds by sharing downloaded stuff
+    # when this is run locally (we could cache via GH action though)
+    os.makedirs("/var/cache/image-builder/store", exist_ok=True)
+    output_dir = tmp_path / "output"
+    output_dir.mkdir()
+    subprocess.check_call([
+        "podman", "run",
+        "--privileged",
+        "-v", "/var/lib/containers/storage:/var/lib/containers/storage",
+        "-v", "/var/cache/image-builder/store:/var/cache/image-builder/store",
+        "-v", f"{output_dir}:/output",
+        build_container,
+        "build",
+        "--progress=verbose",
+        "--output-dir=/output",
+        "container",
+        "--distro", "fedora-41",
+        # selecting a foreign arch here automatically triggers a cross-build
+        f"--arch={arch}",
+    ], text=True)
+    assert os.path.exists(output_dir / f"fedora-41-container-{arch}.tar")


### PR DESCRIPTION
This PR enables automatic cross architecture building when `build --arch <foreign>` is passed. It uses the new generalized bootstrap buildroot feature of images.