### PR TITLE
many: move to use the new github.com/osbuild/blueprint module

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/BurntSushi/toml v1.5.0
 	github.com/cheggaaa/pb/v3 v3.1.7
 	github.com/gobwas/glob v0.2.3
+	github.com/osbuild/blueprint v0.0.0-20250326072213-45708b085654
 	github.com/osbuild/bootc-image-builder/bib v0.0.0-20250220151022-a00d61b94388
 	github.com/osbuild/images v0.127.0
 	github.com/sirupsen/logrus v1.9.3
@@ -34,6 +35,7 @@ require (
 	github.com/containers/libtrust v0.0.0-20230121012942-c1716e8a8d01 // indirect
 	github.com/containers/ocicrypt v1.2.1 // indirect
 	github.com/containers/storage v1.57.1 // indirect
+	github.com/coreos/go-semver v0.3.1 // indirect
 	github.com/cyberphone/json-canonicalization v0.0.0-20231217050601-ba74d44ecf5f // indirect
 	github.com/cyphar/filepath-securejoin v0.3.6 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect

--- a/go.sum
+++ b/go.sum
@@ -6,8 +6,6 @@ github.com/14rcole/gopopulate v0.0.0-20180821133914-b175b219e774/go.mod h1:6/0dY
 github.com/Azure/go-ansiterm v0.0.0-20230124172434-306776ec8161 h1:L/gRVlceqvL25UVaW/CKtUDjefjrs0SPonmDGUVOYP0=
 github.com/Azure/go-ansiterm v0.0.0-20230124172434-306776ec8161/go.mod h1:xomTg63KZ2rFqZQzSB4Vz2SUXa1BpHTVz9L5PTmPC4E=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
-github.com/BurntSushi/toml v1.4.0 h1:kuoIxZQy2WRRk1pttg9asf+WVv6tWQuBNVmK8+nqPr0=
-github.com/BurntSushi/toml v1.4.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
 github.com/BurntSushi/toml v1.5.0 h1:W5quZX/G/csjUnuI8SUYlsHs9M38FC7znL0lIO+DvMg=
 github.com/BurntSushi/toml v1.5.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
 github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=
@@ -55,6 +53,8 @@ github.com/containers/ocicrypt v1.2.1 h1:0qIOTT9DoYwcKmxSt8QJt+VzMY18onl9jUXsxpV
 github.com/containers/ocicrypt v1.2.1/go.mod h1:aD0AAqfMp0MtwqWgHM1bUwe1anx0VazI108CRrSKINQ=
 github.com/containers/storage v1.57.1 h1:hKPoFsuBcB3qTzBxa4IFpZMRzUuL5Xhv/BE44W0XHx8=
 github.com/containers/storage v1.57.1/go.mod h1:i/Hb4lu7YgFr9G0K6BMjqW0BLJO1sFsnWQwj2UoWCUM=
+github.com/coreos/go-semver v0.3.1 h1:yi21YpKnrx1gt5R+la8n5WgS0kCrsPp33dmEyHReZr4=
+github.com/coreos/go-semver v0.3.1/go.mod h1:irMmmIw/7yzSRPWryHsK7EYSg09caPQL03VsM8rvUec=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/cyberphone/json-canonicalization v0.0.0-20231217050601-ba74d44ecf5f h1:eHnXnuK47UlSTOQexbzxAZfekVz6i+LKRdj1CU5DPaM=
 github.com/cyberphone/json-canonicalization v0.0.0-20231217050601-ba74d44ecf5f/go.mod h1:uzvlm1mxhHkdfqitSA92i7Se+S9ksOn3a3qmv/kyOCw=
@@ -234,6 +234,8 @@ github.com/opencontainers/runtime-spec v1.2.0 h1:z97+pHb3uELt/yiAWD691HNHQIF07bE
 github.com/opencontainers/runtime-spec v1.2.0/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/C5hL+LL3ko9hs6T5lQ0=
 github.com/opencontainers/selinux v1.11.1 h1:nHFvthhM0qY8/m+vfhJylliSshm8G1jJ2jDMcgULaH8=
 github.com/opencontainers/selinux v1.11.1/go.mod h1:E5dMC3VPuVvVHDYmi78qvhJp8+M586T4DlDRYpFkyec=
+github.com/osbuild/blueprint v0.0.0-20250326072213-45708b085654 h1:DWl+15w5QlIEOyadc2OaLlWC0BC6d7CfMshssYsXCnI=
+github.com/osbuild/blueprint v0.0.0-20250326072213-45708b085654/go.mod h1:Nf6cZhSb+yL165qe9r8NwtWWRDyfzqI+DVFbLuDqHD0=
 github.com/osbuild/bootc-image-builder/bib v0.0.0-20250220151022-a00d61b94388 h1:Aft5yg8VLd23dPm3dJcg92+bc3UmxsuSw8WnTm5yGpw=
 github.com/osbuild/bootc-image-builder/bib v0.0.0-20250220151022-a00d61b94388/go.mod h1:mfH19B+cceuQ4PJ6FPsciTtuMFdUiAFHmltgXVg65hg=
 github.com/osbuild/images v0.127.0 h1:O77/Gi4WmBe/YnFveG1U55oe895Lly7nzsYfmwyjqL0=

--- a/internal/blueprintload/blueprintload.go
+++ b/internal/blueprintload/blueprintload.go
@@ -9,14 +9,18 @@ import (
 
 	"github.com/BurntSushi/toml"
 
-	"github.com/osbuild/images/pkg/blueprint"
+	// XXX: there should only be one importable blueprint, i.e.
+	// importing the external and passing it to images, if
+	// images needs its own it should not be public
+	externalBlueprint "github.com/osbuild/blueprint/pkg/blueprint"
+	imagesBlueprint "github.com/osbuild/images/pkg/blueprint"
 )
 
 // XXX: move this helper into images, share with bib
-func decodeToml(r io.Reader, what string) (*blueprint.Blueprint, error) {
+func decodeToml(r io.Reader, what string) (*externalBlueprint.Blueprint, error) {
 	dec := toml.NewDecoder(r)
 
-	var conf blueprint.Blueprint
+	var conf externalBlueprint.Blueprint
 	metadata, err := dec.Decode(&conf)
 	if err != nil {
 		return nil, fmt.Errorf("cannot decode %q: %w", what, err)
@@ -28,11 +32,11 @@ func decodeToml(r io.Reader, what string) (*blueprint.Blueprint, error) {
 	return &conf, nil
 }
 
-func decodeJson(r io.Reader, what string) (*blueprint.Blueprint, error) {
+func decodeJson(r io.Reader, what string) (*externalBlueprint.Blueprint, error) {
 	dec := json.NewDecoder(r)
 	dec.DisallowUnknownFields()
 
-	var conf blueprint.Blueprint
+	var conf externalBlueprint.Blueprint
 	if err := dec.Decode(&conf); err != nil {
 		return nil, fmt.Errorf("cannot decode %q: %w", what, err)
 	}
@@ -42,13 +46,13 @@ func decodeJson(r io.Reader, what string) (*blueprint.Blueprint, error) {
 	return &conf, nil
 }
 
-func Load(path string) (*blueprint.Blueprint, error) {
+func load(path string) (*externalBlueprint.Blueprint, error) {
 	var fp io.ReadCloser
 	var err error
 
 	switch path {
 	case "":
-		return &blueprint.Blueprint{}, nil
+		return &externalBlueprint.Blueprint{}, nil
 	case "-":
 		fp = os.Stdin
 	default:
@@ -67,4 +71,15 @@ func Load(path string) (*blueprint.Blueprint, error) {
 	default:
 		return nil, fmt.Errorf("unsupported file extension for %q (please use .toml or .json)", path)
 	}
+}
+
+func Load(path string) (*imagesBlueprint.Blueprint, error) {
+	externalBp, err := load(path)
+	if err != nil {
+		return nil, err
+	}
+	// XXX: make convert a method on "Blueprint"
+	// XXX2: make Convert() take a pointer
+	imagesBp := externalBlueprint.Convert(*externalBp)
+	return &imagesBp, nil
 }


### PR DESCRIPTION
This commit moves ibcli over to use the new `osbuild/blueprint` module for better compatibility with the composer and on-prem blueprints.