### PR TITLE
main: allow seed setting

### DIFF
--- a/cmd/image-builder/main.go
+++ b/cmd/image-builder/main.go
@@ -151,6 +151,14 @@ func cmdManifestWrapper(pbar progress.ProgressBar, cmd *cobra.Command, args []st
 	if err != nil {
 		return nil, err
 	}
+	var customSeed *int64
+	if cmd.Flags().Changed("seed") {
+		seedFlagVal, err := cmd.Flags().GetInt64("seed")
+		if err != nil {
+			return nil, err
+		}
+		customSeed = &seedFlagVal
+	}
 	// no error check here as this is (deliberately) not defined on
 	// "manifest" (if "images" learn to set the output filename in
 	// manifests we would change this
@@ -189,6 +197,7 @@ func cmdManifestWrapper(pbar progress.ProgressBar, cmd *cobra.Command, args []st
 		Ostree:         ostreeImgOpts,
 		RpmDownloader:  rpmDownloader,
 		WithSBOM:       withSBOM,
+		CustomSeed:     customSeed,
 
 		ForceRepos: forceRepos,
 	}
@@ -398,6 +407,7 @@ operating systems like Fedora, CentOS and RHEL with easy customizations support.
 		Hidden:       true,
 	}
 	manifestCmd.Flags().String("blueprint", "", `filename of a blueprint to customize an image`)
+	manifestCmd.Flags().Int64("seed", 0, `rng seed, some values are derived randomly, pinning the seed allows more reproducibility if you need it. must be an integer. only used when changed.`)
 	manifestCmd.Flags().String("arch", "", `build manifest for a different architecture`)
 	manifestCmd.Flags().String("distro", "", `build manifest for a different distroname (e.g. centos-9)`)
 	manifestCmd.Flags().String("ostree-ref", "", `OSTREE reference`)

--- a/cmd/image-builder/manifest.go
+++ b/cmd/image-builder/manifest.go
@@ -24,6 +24,7 @@ type manifestOptions struct {
 	Ostree         *ostree.ImageOptions
 	RpmDownloader  osbuild.RpmDownloader
 	WithSBOM       bool
+	CustomSeed     *int64
 
 	ForceRepos            []string
 	UseBootstrapContainer bool
@@ -55,6 +56,7 @@ func generateManifest(dataDir string, extraRepos []string, img *imagefilter.Resu
 		Output:                output,
 		RpmDownloader:         opts.RpmDownloader,
 		UseBootstrapContainer: opts.UseBootstrapContainer,
+		CustomSeed:            opts.CustomSeed,
 	}
 	if opts.WithSBOM {
 		outputDir := basenameFor(img, opts.OutputDir)


### PR DESCRIPTION
Allow users to define the seed that's used for manifest generation. Regenerating an image with a given seed leads to the same manifest (provided depsolving does the same).

The seed is normally mostly used to generate random filesystem UUIDs.

This will need a bunch of documentation in a follow up since the use cases are meant to be advanced but it can really speed up multi-type and rebuilds of the same image.

---

Note that this is part of an ongoing effort, with this change users can opt for the same manifests being generated (barring depsolve changes). This stops the invalidation of the `os` pipeline, which contains filesystem UUIDs. This can then, in a followup, lead to us check pointing more; allowing us to re-use more.

Related to #114, probably only really useful after https://github.com/osbuild/bootc-image-builder/pull/812
