### PR TITLE
main: rename `list-images` to `list` (with alias for the old names)

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ $ sudo dnf install osbuild osbuild-depsolve-dnf
 
 To see the list of buildable images run:
 ```console
-$ image-builder list-images
+$ image-builder list
 ...
 centos-9 type:qcow2 arch:x86_64
 ...
@@ -161,7 +161,7 @@ after they are built.
 
 When listing images, it is possible to filter:
 ```console
-$ image-builder list-images --filter ami
+$ image-builder list --filter ami
 ...
 centos-9 type:ami arch:x86_64
 ...
@@ -171,7 +171,7 @@ rhel-10.0 type:ami arch:aarch64
 ```
 or be more specific
 ```console
-$ image-builder list-images --filter "arch:x86*" --filter "distro:*centos*"
+$ image-builder list --filter "arch:x86*" --filter "distro:*centos*"
 centos-9 type:ami arch:x86_64
 ...
 centos-9 type:qcow2 arch:x86_64
@@ -188,7 +188,7 @@ The following filters are currently supported, shell-style globbing is supported
 
 The text format can also be switched, supported are "text", "json":
 ```console
-$ image-builder list-images --format=json
+$ image-builder list --format=json
 [
   {
     "distro": {

--- a/cmd/image-builder/filters.go
+++ b/cmd/image-builder/filters.go
@@ -42,7 +42,7 @@ func getOneImage(distroName, imgTypeStr, archStr string, repoOpts *repoOptions) 
 		return nil, err
 	}
 	// strip prefixes to make ib copy/paste friendly when pasting output
-	// from "list-images"
+	// from "list"
 	distroName = strings.TrimPrefix(distroName, "distro:")
 	imgTypeStr = strings.TrimPrefix(imgTypeStr, "type:")
 	archStr = strings.TrimPrefix(archStr, "arch:")

--- a/cmd/image-builder/main.go
+++ b/cmd/image-builder/main.go
@@ -389,16 +389,17 @@ operating systems like Fedora, CentOS and RHEL with easy customizations support.
 	rootCmd.SetOut(osStdout)
 	rootCmd.SetErr(osStderr)
 
-	listImagesCmd := &cobra.Command{
-		Use:          "list-images",
+	listCmd := &cobra.Command{
+		Use:          "list",
 		Short:        "List buildable images, use --filter to limit further",
 		RunE:         cmdListImages,
 		SilenceUsage: true,
 		Args:         cobra.NoArgs,
+        Aliases:      []string{"list-images"},
 	}
-	listImagesCmd.Flags().StringArray("filter", nil, `Filter distributions by a specific criteria (e.g. "type:iot*")`)
-	listImagesCmd.Flags().String("format", "", "Output in a specific format (text, json)")
-	rootCmd.AddCommand(listImagesCmd)
+	listCmd.Flags().StringArray("filter", nil, `Filter distributions by a specific criteria (e.g. "type:iot*")`)
+	listCmd.Flags().String("format", "", "Output in a specific format (text, json)")
+	rootCmd.AddCommand(listCmd)
 
 	manifestCmd := &cobra.Command{
 		Use:          "manifest <image-type>",

--- a/cmd/image-builder/main_test.go
+++ b/cmd/image-builder/main_test.go
@@ -35,7 +35,7 @@ func TestListImagesNoArguments(t *testing.T) {
 	defer restore()
 
 	for _, args := range [][]string{nil, []string{"--format=text"}} {
-		restore = main.MockOsArgs(append([]string{"list-images"}, args...))
+		restore = main.MockOsArgs(append([]string{"list"}, args...))
 		defer restore()
 
 		var fakeStdout bytes.Buffer
@@ -55,7 +55,7 @@ func TestListImagesNoArgsOutputJSON(t *testing.T) {
 	restore := main.MockNewRepoRegistry(testrepos.New)
 	defer restore()
 
-	restore = main.MockOsArgs([]string{"list-images", "--format=json"})
+	restore = main.MockOsArgs([]string{"list", "--format=json"})
 	defer restore()
 
 	var fakeStdout bytes.Buffer
@@ -80,7 +80,7 @@ func TestListImagesFilteringSmoke(t *testing.T) {
 	restore := main.MockNewRepoRegistry(testrepos.New)
 	defer restore()
 
-	restore = main.MockOsArgs([]string{"list-images", "--filter=centos*"})
+	restore = main.MockOsArgs([]string{"list", "--filter=centos*"})
 	defer restore()
 
 	var fakeStdout bytes.Buffer
@@ -113,7 +113,7 @@ func TestListImagesErrorsOnExtraArgs(t *testing.T) {
 	restore := main.MockNewRepoRegistry(testrepos.New)
 	defer restore()
 
-	restore = main.MockOsArgs(append([]string{"list-images"}, "extra-arg"))
+	restore = main.MockOsArgs(append([]string{"list"}, "extra-arg"))
 	defer restore()
 
 	var fakeStdout bytes.Buffer
@@ -121,7 +121,7 @@ func TestListImagesErrorsOnExtraArgs(t *testing.T) {
 	defer restore()
 
 	err := main.Run()
-	assert.EqualError(t, err, `unknown command "extra-arg" for "image-builder list-images"`)
+	assert.EqualError(t, err, `unknown command "extra-arg" for "image-builder list"`)
 }
 
 func hasDepsolveDnf() bool {

--- a/doc/01-usage.md
+++ b/doc/01-usage.md
@@ -5,7 +5,7 @@ After [installation](./00-installation.md) you probably want to use `image-build
 Let's take a look at the available `x86_64` image types for Fedora 41 and build one of them.
 
 ```console
-$ image-builder list-images --filter arch:x86_64 --filter distro:fedora-41
+$ image-builder list --filter arch:x86_64 --filter distro:fedora-41
 fedora-41 type:ami arch:x86_64
 fedora-41 type:container arch:x86_64
 fedora-41 type:image-installer arch:x86_64
@@ -29,21 +29,21 @@ $ sudo image-builder build --distro fedora-41 qcow2
 # ...
 ```
 
-## `image-builder list-images`
+## `image-builder list`
 
-The `list-images` command for `image-builder` lists the available built-in image types that can be built for the [built-in distributions](./10-faq.md#built-in-distributions).
+The `list` command for `image-builder` lists the available built-in image types that can be built for the [built-in distributions](./10-faq.md#built-in-distributions).
 
 ```console
-$ image-builder list-images
+$ image-builder list
 # ... long list ...
 ```
 
 ### Format
 
-The output format used by `list-images` can be swapped with the `--format` flag. Available types are `text` (for display in a terminal) and `json` which can be useful to consume programmatically:
+The output format used by `list` can be swapped with the `--format` flag. Available types are `text` (for display in a terminal) and `json` which can be useful to consume programmatically:
 
 ```console
-$ image-builder list-images --format=json | jq '.[0]'
+$ image-builder list --format=json | jq '.[0]'
 {
   "distro": {
     "name": "centos-9"
@@ -59,14 +59,14 @@ $ image-builder list-images --format=json | jq '.[0]'
 
 ### Filtering
 
-`list-images` output can be filtered with the `--filter` argument.
+`list` output can be filtered with the `--filter` argument.
 
 ### Distribution
 
 To filter on a given distribution, one can use `--filter` with the `distro:` prefix:
 
 ```console
-$ image-builder list-images --filter distro:fedora-41
+$ image-builder list --filter distro:fedora-41
 # ... long list ...
 ```
 
@@ -75,7 +75,7 @@ $ image-builder list-images --filter distro:fedora-41
 To filter on a given [image type](./10-faq.md#image-types) the `type:` prefix:
 
 ```console
-$ image-builder list-images --filter type:qcow2
+$ image-builder list --filter type:qcow2
 # ... long list ...
 ```
 ### Architecture
@@ -83,7 +83,7 @@ $ image-builder list-images --filter type:qcow2
 To filter on a given architecture use the `arch:` prefix:
 
 ```console
-$ image-builder list-images --filter arch:aarch64
+$ image-builder list --filter arch:aarch64
 # ... long list ...
 ```
 
@@ -92,7 +92,7 @@ $ image-builder list-images --filter arch:aarch64
 Filters can be combined to narrow the list further.
 
 ```console
-$ image-builder list-images --filter type:qcow2 --filter distro:fedora-41
+$ image-builder list --filter type:qcow2 --filter distro:fedora-41
 # ... list ...
 ```
 


### PR DESCRIPTION
Rename the `list-images` command to `list`. We don't have `-image(s)` in our other subcommands so this is for consistency.

We keep a `list-images` alias behind for compatibility reasons.

---

Closes #78, name can be discussed but the initial issue didn't garner attention.