### PR TITLE
progress: set --cache-max-size in osbuild

### DIFF
--- a/pkg/progress/progress_test.go
+++ b/pkg/progress/progress_test.go
@@ -263,3 +263,21 @@ osbuild-stderr-output
 `
 	assert.Equal(t, expectedOutput, buildLog.String())
 }
+
+func TestRunOSBuildCacheMaxSize(t *testing.T) {
+	fakeOsbuildBinary := makeFakeOsbuild(t, `echo "$@" > "$0".cmdline`)
+	restore := progress.MockOsbuildCmd(fakeOsbuildBinary)
+	defer restore()
+
+	pbar, err := progress.New("debug")
+	assert.NoError(t, err)
+
+	osbuildOpts := &progress.OSBuildOptions{
+		CacheMaxSize: 77,
+	}
+	err = progress.RunOSBuild(pbar, []byte(`{"fake":"manifest"}`), nil, osbuildOpts)
+	assert.NoError(t, err)
+	cmdline, err := os.ReadFile(fakeOsbuildBinary + ".cmdline")
+	assert.NoError(t, err)
+	assert.Contains(t, string(cmdline), "--cache-max-size=77")
+}


### PR DESCRIPTION
This commit allows controlling the `osbuild --cache-max-size` option. By default it will set the cache to 20GiB but allows this to be controlled by the user.

Thanks to Simon for raising this.

---

Commit imported from https://github.com/osbuild/bootc-image-builder/pull/812