### PR TITLE
main: add base partition table to `describe-image`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/gobwas/glob v0.2.3
 	github.com/osbuild/blueprint v1.1.0
 	github.com/osbuild/bootc-image-builder/bib v0.0.0-20250220151022-a00d61b94388
-	github.com/osbuild/images v0.127.0
+	github.com/osbuild/images v0.131.0
 	github.com/sirupsen/logrus v1.9.3
 	github.com/spf13/cobra v1.9.1
 	github.com/stretchr/testify v1.10.0

--- a/go.sum
+++ b/go.sum
@@ -240,6 +240,10 @@ github.com/osbuild/bootc-image-builder/bib v0.0.0-20250220151022-a00d61b94388 h1
 github.com/osbuild/bootc-image-builder/bib v0.0.0-20250220151022-a00d61b94388/go.mod h1:mfH19B+cceuQ4PJ6FPsciTtuMFdUiAFHmltgXVg65hg=
 github.com/osbuild/images v0.127.0 h1:O77/Gi4WmBe/YnFveG1U55oe895Lly7nzsYfmwyjqL0=
 github.com/osbuild/images v0.127.0/go.mod h1:Ag87vmyxooiPQBJEDILbypG8/SRIear75YA78NwLix0=
+github.com/osbuild/images v0.130.0 h1:nXBj4rpgupF4i1W9NoY4gtmrCTQSC3yaJOkXxBNAvX8=
+github.com/osbuild/images v0.130.0/go.mod h1:Ag87vmyxooiPQBJEDILbypG8/SRIear75YA78NwLix0=
+github.com/osbuild/images v0.131.0 h1:UbAS2OtJa4iKJYIBE+TRhODGsA4N5hxZLHnevnImLmQ=
+github.com/osbuild/images v0.131.0/go.mod h1:Ag87vmyxooiPQBJEDILbypG8/SRIear75YA78NwLix0=
 github.com/ostreedev/ostree-go v0.0.0-20210805093236-719684c64e4f h1:/UDgs8FGMqwnHagNDPGOlts35QkhAZ8by3DR7nMih7M=
 github.com/ostreedev/ostree-go v0.0.0-20210805093236-719684c64e4f/go.mod h1:J6OG6YJVEWopen4avK3VNQSnALmmjvniMmni/YFYAwc=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=


### PR DESCRIPTION
[draft as it needs https://github.com/osbuild/images/pull/1376 first and once that is in we need to drop the "go mod edit -replace"  commit, also we need to think if that should be `partition_table` or `base_partition_table` in the output]

This commit adds the (base) partition table to the `describe-image`
command. It needs https://github.com/osbuild/images/pull/1376

It currently looks like:
```yaml
$ image-builder describe-image qcow2 --distro fedora-41
@WARNING - the output format is not stable yet and may change
distro: fedora-41
...
partition_table:
  uuid: D209C89E-EA5E-4FBD-B161-B461CCE297E0
  type: gpt
  partitions:
    - size: 1048576
      type: 21686148-6449-6E6F-744E-656564454649
      bootable: true
      uuid: FAC7F1FB-3E8D-4137-A512-961DE09A5549
    - size: 209715200
      type: C12A7328-F81F-11D2-BA4B-00A0C93EC93B
      uuid: 68B2905B-DF3E-4FB3-80FA-49D1E773AA33
      payload:
        type: vfat
        uuid: 7B77-95E7
        label: EFI-SYSTEM
        mountpoint: /boot/efi
        fstab_options: defaults,uid=0,gid=0,umask=077,shortname=winnt
        fstab_passno: 2
    - size: 524288000
      type: 0FC63DAF-8483-4772-8E79-3D69D8477DE4
      uuid: CB07C243-BC44-4717-853E-28852021225B
      payload:
        type: ext4
        label: boot
        mountpoint: /boot
        fstab_options: defaults
    - size: 2147483648
      type: 0FC63DAF-8483-4772-8E79-3D69D8477DE4
      uuid: 6264D520-3FB9-423F-8AB8-7A0A8E3D3562
      payload:
        type: ext4
        label: root
        mountpoint: /
        fstab_options: defaults
```
