### PR TITLE
GH Action: check the SPEC osbuild/images deps minimum version

### DIFF
--- a/.github/workflows/check-spec.yaml
+++ b/.github/workflows/check-spec.yaml
@@ -1,0 +1,35 @@
+name: SPEC file check
+
+on:  # yamllint disable-line rule:truthy
+  pull_request:
+    branches:
+      - "*"
+  push:
+    branches:
+      - main
+
+jobs:
+  check-spec-images-deps:
+    name: "🔍 Check spec file osbuild/images dependencies"
+    runs-on: ubuntu-latest
+    container: registry.fedoraproject.org/fedora:latest
+    env:
+      # workaround for expired cert at source of indirect dependency
+      # (go.opencensus.io/trace)
+      GOPROXY: "https://proxy.golang.org,direct"
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install dependencies
+        shell: bash
+        run: |
+          # we have the same build-deps as the images library
+          curl -sL https://raw.githubusercontent.com/osbuild/images/refs/heads/main/test/scripts/install-dependencies | bash
+
+      - name: Vendor dependencies
+        run: go mod vendor
+
+      - name: Check dependencies in spec file
+        uses: osbuild/images@check-spec-deps-action

--- a/image-builder.spec
+++ b/image-builder.spec
@@ -3,7 +3,7 @@
 # required. So if this needs backport to places where there is no
 # recent osbuild available we could simply make --use-librepo false
 # and go back to 129.
-%global min_osbuild_version 138
+%global min_osbuild_version 142
 
 %global goipath         github.com/osbuild/image-builder-cli
 


### PR DESCRIPTION
Add a check which leverages the osbuild/images@check-spec-deps-action action to check that the SPEC files requires at least the minimum versions for dependencies specified by the `osbuild/images`.