### PR TITLE
main: eat depsolve warnings

### DIFF
--- a/cmd/image-builder/main.go
+++ b/cmd/image-builder/main.go
@@ -216,7 +216,7 @@ func cmdManifest(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	_, err = cmdManifestWrapper(pbar, cmd, args, osStdout, osStderr, nil)
+	_, err = cmdManifestWrapper(pbar, cmd, args, osStdout, io.Discard, nil)
 	return err
 }
 

--- a/cmd/image-builder/main.go
+++ b/cmd/image-builder/main.go
@@ -101,7 +101,7 @@ type cmdManifestWrapperOptions struct {
 	useBootstrapIfNeeded bool
 }
 
-func cmdManifestWrapper(pbar progress.ProgressBar, cmd *cobra.Command, args []string, w io.Writer, wrapperOpts *cmdManifestWrapperOptions) (*imagefilter.Result, error) {
+func cmdManifestWrapper(pbar progress.ProgressBar, cmd *cobra.Command, args []string, w io.Writer, wd io.Writer, wrapperOpts *cmdManifestWrapperOptions) (*imagefilter.Result, error) {
 	if wrapperOpts == nil {
 		wrapperOpts = &cmdManifestWrapperOptions{}
 	}
@@ -207,7 +207,7 @@ func cmdManifestWrapper(pbar progress.ProgressBar, cmd *cobra.Command, args []st
 		fmt.Fprintf(os.Stderr, "WARNING: using experimental cross-architecture building to build %q\n", img.Arch.Name())
 	}
 
-	err = generateManifest(dataDir, extraRepos, img, w, opts)
+	err = generateManifest(dataDir, extraRepos, img, w, wd, opts)
 	return img, err
 }
 
@@ -216,7 +216,7 @@ func cmdManifest(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	_, err = cmdManifestWrapper(pbar, cmd, args, osStdout, nil)
+	_, err = cmdManifestWrapper(pbar, cmd, args, osStdout, osStderr, nil)
 	return err
 }
 
@@ -287,7 +287,10 @@ func cmdBuild(cmd *cobra.Command, args []string) error {
 	opts := &cmdManifestWrapperOptions{
 		useBootstrapIfNeeded: true,
 	}
-	res, err := cmdManifestWrapper(pbar, cmd, args, &mf, opts)
+
+	// We discard any warnings from the depsolver until we figure out a better
+	// idea (likely in manifestgen)
+	res, err := cmdManifestWrapper(pbar, cmd, args, &mf, io.Discard, opts)
 	if err != nil {
 		return err
 	}

--- a/cmd/image-builder/manifest.go
+++ b/cmd/image-builder/manifest.go
@@ -46,17 +46,18 @@ func sbomWriter(outputDir, filename string, content io.Reader) error {
 	return nil
 }
 
-func generateManifest(dataDir string, extraRepos []string, img *imagefilter.Result, output io.Writer, opts *manifestOptions) error {
+func generateManifest(dataDir string, extraRepos []string, img *imagefilter.Result, output io.Writer, depsolveWarningsOutput io.Writer, opts *manifestOptions) error {
 	repos, err := newRepoRegistry(dataDir, extraRepos)
 	if err != nil {
 		return err
 	}
 	// XXX: add --rpmmd/cachedir option like bib
 	manifestGenOpts := &manifestgen.Options{
-		Output:                output,
-		RpmDownloader:         opts.RpmDownloader,
-		UseBootstrapContainer: opts.UseBootstrapContainer,
-		CustomSeed:            opts.CustomSeed,
+		Output:                 output,
+		DepsolveWarningsOutput: depsolveWarningsOutput,
+		RpmDownloader:          opts.RpmDownloader,
+		UseBootstrapContainer:  opts.UseBootstrapContainer,
+		CustomSeed:             opts.CustomSeed,
 	}
 	if opts.WithSBOM {
 		outputDir := basenameFor(img, opts.OutputDir)

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/gobwas/glob v0.2.3
 	github.com/osbuild/blueprint v1.1.0
 	github.com/osbuild/bootc-image-builder/bib v0.0.0-20250220151022-a00d61b94388
-	github.com/osbuild/images v0.131.0
+	github.com/osbuild/images v0.132.1-0.20250407125100-c141eba8280b
 	github.com/sirupsen/logrus v1.9.3
 	github.com/spf13/cobra v1.9.1
 	github.com/stretchr/testify v1.10.0

--- a/go.sum
+++ b/go.sum
@@ -244,6 +244,10 @@ github.com/osbuild/images v0.130.0 h1:nXBj4rpgupF4i1W9NoY4gtmrCTQSC3yaJOkXxBNAvX
 github.com/osbuild/images v0.130.0/go.mod h1:Ag87vmyxooiPQBJEDILbypG8/SRIear75YA78NwLix0=
 github.com/osbuild/images v0.131.0 h1:UbAS2OtJa4iKJYIBE+TRhODGsA4N5hxZLHnevnImLmQ=
 github.com/osbuild/images v0.131.0/go.mod h1:Ag87vmyxooiPQBJEDILbypG8/SRIear75YA78NwLix0=
+github.com/osbuild/images v0.132.0 h1:0QlLw+hymhlao8f3V2Y/Mb15dK4vKBfja0dxxT8zwqA=
+github.com/osbuild/images v0.132.0/go.mod h1:Ag87vmyxooiPQBJEDILbypG8/SRIear75YA78NwLix0=
+github.com/osbuild/images v0.132.1-0.20250407125100-c141eba8280b h1:frZTrxFvMx6Har2r8ZjHS/JkTO3k7a5HTBEYGU9Qh/0=
+github.com/osbuild/images v0.132.1-0.20250407125100-c141eba8280b/go.mod h1:Ag87vmyxooiPQBJEDILbypG8/SRIear75YA78NwLix0=
 github.com/ostreedev/ostree-go v0.0.0-20210805093236-719684c64e4f h1:/UDgs8FGMqwnHagNDPGOlts35QkhAZ8by3DR7nMih7M=
 github.com/ostreedev/ostree-go v0.0.0-20210805093236-719684c64e4f/go.mod h1:J6OG6YJVEWopen4avK3VNQSnALmmjvniMmni/YFYAwc=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=

--- a/image-builder.spec
+++ b/image-builder.spec
@@ -3,7 +3,7 @@
 # required. So if this needs backport to places where there is no
 # recent osbuild available we could simply make --use-librepo false
 # and go back to 129.
-%global min_osbuild_version 142
+%global min_osbuild_version 146
 
 %global goipath         github.com/osbuild/image-builder-cli
 


### PR DESCRIPTION
When running `image-builder` warnings are emitted during manifest generation. Depending on the definitions or customizations packages can be excluded from groups which leads to:

```
No match for group package "dracut-config-rescue"
```

Interspersing with normal output. Let's pass along another byte buffer for the warnings from manifest generation to be written into.

Note that this also needs plumbing [1] to land in `images` first.

[1]: https://github.com/osbuild/images/pull/1384

---

Draft until `images` lands since until then everything in here will be RED.