### PR TITLE
main: rename `describe-image` to `describe`

### DIFF
--- a/cmd/image-builder/main.go
+++ b/cmd/image-builder/main.go
@@ -455,12 +455,13 @@ operating systems like Fedora, CentOS and RHEL with easy customizations support.
 
 	// XXX: add --format=json too?
 	describeImgCmd := &cobra.Command{
-		Use:          "describe-image <image-type>",
+		Use:          "describe <image-type>",
 		Short:        "Describe the given image-type, e.g. qcow2 (tip: combine with --distro,--arch)",
 		RunE:         cmdDescribeImg,
 		SilenceUsage: true,
 		Args:         cobra.ExactArgs(1),
 		Hidden:       true,
+		Aliases:      []string{"describe-image"},
 	}
 	describeImgCmd.Flags().String("arch", "", `use the different architecture`)
 	describeImgCmd.Flags().String("distro", "", `build manifest for a different distroname (e.g. centos-9)`)

--- a/cmd/image-builder/main_test.go
+++ b/cmd/image-builder/main_test.go
@@ -688,7 +688,7 @@ func TestDescribeImageSmoke(t *testing.T) {
 	defer restore()
 
 	restore = main.MockOsArgs([]string{
-		"describe-image",
+		"describe",
 		"qcow2",
 		"--distro=centos-9",
 		"--arch=x86_64",


### PR DESCRIPTION
Leaves behind a compatibility alias.

---

Split out from #177.