### PR TITLE
many: add support for unpriviledged building (HMS-5955)

### DIFF
--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -37,7 +37,12 @@ jobs:
       - name: Install cross build dependencies
         run: sudo apt install -y qemu-user-static
 
-      - name: Run integration tests via pytest
+      - name: Run integration tests via pytest (root)
         run: |
           # use "-s" for now for easier debugging
           sudo pytest -s -v
+
+      - name: Run integration tests via pytest (non-root)
+        run: |
+          # use "-s" for now for easier debugging
+          pytest -s -v

--- a/Containerfile
+++ b/Containerfile
@@ -16,9 +16,12 @@ FROM registry.fedoraproject.org/fedora:41
 # podman mount needs this
 RUN mkdir -p /etc/containers/networks
 # Fast-track osbuild so we don't depend on the "slow" Fedora release process to implement new features in bib
+# Add kernel, iproute, dhcp-client, etc for rootless builds via supermin
 RUN dnf install -y dnf-plugins-core \
     && dnf copr enable -y @osbuild/osbuild \
-    && dnf install -y libxcrypt-compat wget osbuild osbuild-ostree osbuild-depsolve-dnf osbuild-lvm2 \
+    && dnf install -y libxcrypt-compat wget osbuild osbuild-ostree \
+    osbuild-depsolve-dnf osbuild-lvm2 supermin qemu-kvm qemu-user-static \
+    podman iproute dhcp-client kernel lvm2 rsync virtiofsd \
     && dnf clean all
 
 COPY --from=builder /build/image-builder /usr/bin/

--- a/cmd/image-builder/export_test.go
+++ b/cmd/image-builder/export_test.go
@@ -12,12 +12,13 @@ import (
 )
 
 var (
-	GetOneImage     = getOneImage
-	Run             = run
-	FindDistro      = findDistro
-	DescribeImage   = describeImage
-	ProgressFromCmd = progressFromCmd
-	BasenameFor     = basenameFor
+	GetOneImage                 = getOneImage
+	Run                         = run
+	FindDistro                  = findDistro
+	DescribeImage               = describeImage
+	ProgressFromCmd             = progressFromCmd
+	BasenameFor                 = basenameFor
+	ImageBuilderDefaultCacheDir = imageBuilderDefaultCacheDir
 )
 
 func MockOsArgs(new []string) (restore func()) {
@@ -41,6 +42,14 @@ func MockOsStderr(new io.Writer) (restore func()) {
 	osStderr = new
 	return func() {
 		osStderr = saved
+	}
+}
+
+func MockOsGetuid(new func() int) (restore func()) {
+	saved := osGetuid
+	osGetuid = new
+	return func() {
+		osGetuid = saved
 	}
 }
 

--- a/cmd/image-builder/main_test.go
+++ b/cmd/image-builder/main_test.go
@@ -164,6 +164,7 @@ func TestManifestIntegrationSmoke(t *testing.T) {
 	if !hasDepsolveDnf() {
 		t.Skip("no osbuild-depsolve-dnf binary found")
 	}
+	t.Setenv("IMAGE_BUILDER_EXPERIMENTAL", "skip-priv-checks")
 
 	restore := main.MockNewRepoRegistry(testrepos.New)
 	defer restore()
@@ -364,6 +365,7 @@ func TestBuildIntegrationHappy(t *testing.T) {
 	if !hasDepsolveDnf() {
 		t.Skip("no osbuild-depsolve-dnf binary found")
 	}
+	t.Setenv("IMAGE_BUILDER_EXPERIMENTAL", "skip-priv-checks")
 
 	restore := main.MockNewRepoRegistry(testrepos.New)
 	defer restore()
@@ -425,6 +427,7 @@ func TestBuildIntegrationArgs(t *testing.T) {
 	if !hasDepsolveDnf() {
 		t.Skip("no osbuild-depsolve-dnf binary found")
 	}
+	t.Setenv("IMAGE_BUILDER_EXPERIMENTAL", "skip-priv-checks")
 
 	restore := main.MockNewRepoRegistry(testrepos.New)
 	defer restore()
@@ -514,6 +517,7 @@ func TestBuildIntegrationErrorsProgressVerbose(t *testing.T) {
 	if !hasDepsolveDnf() {
 		t.Skip("no osbuild-depsolve-dnf binary found")
 	}
+	t.Setenv("IMAGE_BUILDER_EXPERIMENTAL", "skip-priv-checks")
 
 	restore := main.MockNewRepoRegistry(testrepos.New)
 	defer restore()
@@ -548,6 +552,7 @@ func TestBuildIntegrationErrorsProgressVerboseWithBuildlog(t *testing.T) {
 	if !hasDepsolveDnf() {
 		t.Skip("no osbuild-depsolve-dnf binary found")
 	}
+	t.Setenv("IMAGE_BUILDER_EXPERIMENTAL", "skip-priv-checks")
 
 	restore := main.MockNewRepoRegistry(testrepos.New)
 	defer restore()
@@ -597,6 +602,7 @@ func TestBuildIntegrationErrorsProgressTerm(t *testing.T) {
 	if !hasDepsolveDnf() {
 		t.Skip("no osbuild-depsolve-dnf binary found")
 	}
+	t.Setenv("IMAGE_BUILDER_EXPERIMENTAL", "skip-priv-checks")
 
 	restore := main.MockNewRepoRegistry(testrepos.New)
 	defer restore()
@@ -852,6 +858,7 @@ func TestBuildCrossArchSmoke(t *testing.T) {
 	if !hasDepsolveDnf() {
 		t.Skip("no osbuild-depsolve-dnf binary found")
 	}
+	t.Setenv("IMAGE_BUILDER_EXPERIMENTAL", "skip-priv-checks")
 
 	restore := main.MockNewRepoRegistry(testrepos.New)
 	defer restore()
@@ -904,6 +911,7 @@ func TestBuildIntegrationOutputFilename(t *testing.T) {
 	if !hasDepsolveDnf() {
 		t.Skip("no osbuild-depsolve-dnf binary found")
 	}
+	t.Setenv("IMAGE_BUILDER_EXPERIMENTAL", "skip-priv-checks")
 
 	restore := main.MockNewRepoRegistry(testrepos.New)
 	defer restore()

--- a/cmd/image-builder/upload_test.go
+++ b/cmd/image-builder/upload_test.go
@@ -128,6 +128,7 @@ func TestBuildAndUploadWithAWSMock(t *testing.T) {
 	if !hasDepsolveDnf() {
 		t.Skip("no osbuild-depsolve-dnf binary found")
 	}
+	t.Setenv("IMAGE_BUILDER_EXPERIMENTAL", "skip-priv-checks")
 
 	var regionName, bucketName, amiName string
 	var fa fakeAwsUploader
@@ -177,6 +178,7 @@ func TestBuildAmiButNotUpload(t *testing.T) {
 	if !hasDepsolveDnf() {
 		t.Skip("no osbuild-depsolve-dnf binary found")
 	}
+	t.Setenv("IMAGE_BUILDER_EXPERIMENTAL", "skip-priv-checks")
 
 	fa := fakeAwsUploader{
 		uploadAndRegisterErr: fmt.Errorf("upload should not be called"),

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/BurntSushi/toml v1.5.1-0.20250403130103-3d3abc24416a
 	github.com/cheggaaa/pb/v3 v3.1.7
 	github.com/gobwas/glob v0.2.3
+	github.com/google/uuid v1.6.0
 	github.com/mattn/go-isatty v0.0.20
 	github.com/osbuild/blueprint v1.5.0
 	github.com/osbuild/images v0.135.0
@@ -66,7 +67,6 @@ require (
 	github.com/golang/protobuf v1.5.4 // indirect
 	github.com/google/go-containerregistry v0.20.2 // indirect
 	github.com/google/go-intervals v0.0.2 // indirect
-	github.com/google/uuid v1.6.0 // indirect
 	github.com/gorilla/mux v1.8.1 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-multierror v1.1.1 // indirect

--- a/pkg/progress/export_test.go
+++ b/pkg/progress/export_test.go
@@ -11,7 +11,8 @@ type (
 )
 
 var (
-	NewSyncedWriter = newSyncedWriter
+	NewSyncedWriter       = newSyncedWriter
+	EnoughPrivsForOsbuild = enoughPrivsForOsbuild
 )
 
 func MockOsStdout(w io.Writer) (restore func()) {
@@ -43,5 +44,13 @@ func MockOsbuildCmd(s string) (restore func()) {
 	osbuildCmd = s
 	return func() {
 		osbuildCmd = saved
+	}
+}
+
+func MockEnoughPrivsForOsbuild(new func() (bool, error)) (restore func()) {
+	saved := enoughPrivsForOsbuild
+	enoughPrivsForOsbuild = new
+	return func() {
+		enoughPrivsForOsbuild = saved
 	}
 }

--- a/pkg/progress/export_test.go
+++ b/pkg/progress/export_test.go
@@ -13,6 +13,7 @@ type (
 var (
 	NewSyncedWriter       = newSyncedWriter
 	EnoughPrivsForOsbuild = enoughPrivsForOsbuild
+	WaitForFiles          = waitForFiles
 )
 
 func MockOsStdout(w io.Writer) (restore func()) {

--- a/pkg/progress/progress.go
+++ b/pkg/progress/progress.go
@@ -1,23 +1,16 @@
 package progress
 
 import (
-	"bytes"
 	"errors"
 	"fmt"
 	"io"
 	"os"
-	"os/exec"
 	"strings"
-	"sync"
-	"syscall"
 	"time"
 
 	"github.com/cheggaaa/pb/v3"
 	"github.com/mattn/go-isatty"
 	"github.com/sirupsen/logrus"
-
-	"github.com/osbuild/images/pkg/datasizes"
-	"github.com/osbuild/images/pkg/osbuild"
 )
 
 var (
@@ -319,190 +312,5 @@ func (b *debugProgressBar) Stop() {
 func (b *debugProgressBar) SetProgress(subLevel int, msg string, done int, total int) error {
 	fmt.Fprintf(b.w, "%s[%v / %v] %s", strings.Repeat("  ", subLevel), done, total, msg)
 	fmt.Fprintf(b.w, "\n")
-	return nil
-}
-
-type OSBuildOptions struct {
-	StoreDir  string
-	OutputDir string
-	ExtraEnv  []string
-
-	// BuildLog writes the osbuild output to the given writer
-	BuildLog io.Writer
-
-	CacheMaxSize int64
-}
-
-// XXX: merge variant back into images/pkg/osbuild/osbuild-exec.go
-func RunOSBuild(pb ProgressBar, manifest []byte, exports []string, opts *OSBuildOptions) error {
-	if opts == nil {
-		opts = &OSBuildOptions{}
-	}
-
-	// To keep maximum compatibility keep the old behavior to run osbuild
-	// directly and show all messages unless we have a "real" progress bar.
-	//
-	// This should ensure that e.g. "podman bootc" keeps working as it
-	// is currently expecting the raw osbuild output. Once we double
-	// checked with them we can remove the runOSBuildNoProgress() and
-	// just run with the new runOSBuildWithProgress() helper.
-	switch pb.(type) {
-	case *terminalProgressBar, *debugProgressBar:
-		return runOSBuildWithProgress(pb, manifest, exports, opts)
-	default:
-		return runOSBuildNoProgress(pb, manifest, exports, opts)
-	}
-}
-
-func newOsbuildCmd(manifest []byte, exports []string, opts *OSBuildOptions) *exec.Cmd {
-	cacheMaxSize := int64(20 * datasizes.GiB)
-	if opts.CacheMaxSize != 0 {
-		cacheMaxSize = opts.CacheMaxSize
-	}
-	cmd := exec.Command(
-		osbuildCmd,
-		"--store", opts.StoreDir,
-		"--output-directory", opts.OutputDir,
-		fmt.Sprintf("--cache-max-size=%v", cacheMaxSize),
-		"-",
-	)
-	for _, export := range exports {
-		cmd.Args = append(cmd.Args, "--export", export)
-	}
-	cmd.Env = append(os.Environ(), opts.ExtraEnv...)
-	cmd.Stdin = bytes.NewBuffer(manifest)
-	return cmd
-}
-
-func runOSBuildNoProgress(pb ProgressBar, manifest []byte, exports []string, opts *OSBuildOptions) error {
-	var stdout, stderr io.Writer
-
-	var writeMu sync.Mutex
-	if opts.BuildLog == nil {
-		// No external build log requested and we won't need an
-		// internal one because all output goes directly to
-		// stdout/stderr. This is for maximum compatibility with
-		// the existing bootc-image-builder in "verbose" mode
-		// where stdout, stderr come directly from osbuild.
-		stdout = osStdout()
-		stderr = osStderr()
-	} else {
-		// There is a slight wrinkle here: when requesting a
-		// buildlog we can no longer write to separate
-		// stdout/stderr streams without being racy and give
-		// potential out-of-order output (which is very bad
-		// and confusing in a log). The reason is that if
-		// cmd.Std{out,err} are different "go" will start two
-		// go-routine to monitor/copy those are racy when both
-		// stdout,stderr output happens close together
-		// (TestRunOSBuildWithBuildlog demos that). We cannot
-		// have our cake and eat it so here we need to combine
-		// osbuilds stderr into our stdout.
-		mw := newSyncedWriter(&writeMu, io.MultiWriter(osStdout(), opts.BuildLog))
-		stdout = mw
-		stderr = mw
-	}
-
-	cmd := newOsbuildCmd(manifest, exports, opts)
-	cmd.Stdout = stdout
-	cmd.Stderr = stderr
-	if err := cmd.Run(); err != nil {
-		return fmt.Errorf("error running osbuild: %w", err)
-	}
-	return nil
-}
-
-var osbuildCmd = "osbuild"
-
-func runOSBuildWithProgress(pb ProgressBar, manifest []byte, exports []string, opts *OSBuildOptions) (err error) {
-	rp, wp, err := os.Pipe()
-	if err != nil {
-		return fmt.Errorf("cannot create pipe for osbuild: %w", err)
-	}
-	defer rp.Close()
-	defer wp.Close()
-
-	cmd := newOsbuildCmd(manifest, exports, opts)
-	cmd.Args = append(cmd.Args, "--monitor=JSONSeqMonitor")
-	cmd.Args = append(cmd.Args, "--monitor-fd=3")
-
-	var stdio bytes.Buffer
-	var mw, buildLog io.Writer
-	var writeMu sync.Mutex
-	if opts.BuildLog != nil {
-		mw = newSyncedWriter(&writeMu, io.MultiWriter(&stdio, opts.BuildLog))
-		buildLog = newSyncedWriter(&writeMu, opts.BuildLog)
-	} else {
-		mw = &stdio
-		buildLog = io.Discard
-	}
-
-	cmd.Stdout = mw
-	cmd.Stderr = mw
-	cmd.ExtraFiles = []*os.File{wp}
-
-	osbuildStatus := osbuild.NewStatusScanner(rp)
-	if err := cmd.Start(); err != nil {
-		return fmt.Errorf("error starting osbuild: %v", err)
-	}
-	wp.Close()
-	defer func() {
-		// Try to stop osbuild if we exit early, we are gentle
-		// here to give osbuild the chance to release its
-		// resources (like mounts in the buildroot). This is
-		// best effort only (but also a pretty uncommon error
-		// condition). If ProcessState is set the process has
-		// already exited and we have nothing to do.
-		if err != nil && cmd.Process != nil && cmd.ProcessState == nil {
-			sigErr := cmd.Process.Signal(syscall.SIGINT)
-			err = errors.Join(err, sigErr)
-		}
-	}()
-
-	var tracesMsgs []string
-	for {
-		st, err := osbuildStatus.Status()
-		if err != nil {
-			// This should never happen but if it does we try
-			// to be helpful. We need to exit here (and kill
-			// osbuild in the defer) or we would appear to be
-			// handing as cmd.Wait() would wait to finish but
-			// no progress or other message is reported. We
-			// can also not (in the general case) recover as
-			// the underlying osbuildStatus.scanner maybe in
-			// an unrecoverable state (like ErrTooBig).
-			return fmt.Errorf(`error parsing osbuild status, please report a bug and try with "--progress=verbose": %w`, err)
-		}
-		if st == nil {
-			break
-		}
-		i := 0
-		for p := st.Progress; p != nil; p = p.SubProgress {
-			if err := pb.SetProgress(i, p.Message, p.Done, p.Total); err != nil {
-				logrus.Warnf("cannot set progress: %v", err)
-			}
-			i++
-		}
-		// forward to user
-		if st.Message != "" {
-			pb.SetMessagef(st.Message)
-		}
-
-		// keep internal log for error reporting, forward to
-		// external build log
-		if st.Message != "" {
-			tracesMsgs = append(tracesMsgs, st.Message)
-			fmt.Fprintln(buildLog, st.Message)
-		}
-		if st.Trace != "" {
-			tracesMsgs = append(tracesMsgs, st.Trace)
-			fmt.Fprintln(buildLog, st.Trace)
-		}
-	}
-
-	if err := cmd.Wait(); err != nil {
-		return fmt.Errorf("error running osbuild: %w\nBuildLog:\n%s\nOutput:\n%s", err, strings.Join(tracesMsgs, "\n"), stdio.String())
-	}
-
 	return nil
 }

--- a/pkg/progress/progress_test.go
+++ b/pkg/progress/progress_test.go
@@ -16,6 +16,11 @@ import (
 )
 
 func TestProgressNew(t *testing.T) {
+	restore := progress.MockEnoughPrivsForOsbuild(func() (bool, error) {
+		return true, nil
+	})
+	defer restore()
+
 	for _, tc := range []struct {
 		typ         string
 		expected    interface{}
@@ -143,7 +148,12 @@ func makeFakeOsbuild(t *testing.T, content string) string {
 }
 
 func TestRunOSBuildWithProgressErrorReporting(t *testing.T) {
-	restore := progress.MockOsStderr(io.Discard)
+	restore := progress.MockEnoughPrivsForOsbuild(func() (bool, error) {
+		return true, nil
+	})
+	defer restore()
+
+	restore = progress.MockOsStderr(io.Discard)
 	defer restore()
 
 	restore = progress.MockOsbuildCmd(makeFakeOsbuild(t, `
@@ -168,9 +178,14 @@ osbuild-stderr-output
 }
 
 func TestRunOSBuildWithProgressIncorrectJSON(t *testing.T) {
+	restore := progress.MockEnoughPrivsForOsbuild(func() (bool, error) {
+		return true, nil
+	})
+	defer restore()
+
 	signalDeliveredMarkerPath := filepath.Join(t.TempDir(), "sigint-delivered")
 
-	restore := progress.MockOsbuildCmd(makeFakeOsbuild(t, fmt.Sprintf(`
+	restore = progress.MockOsbuildCmd(makeFakeOsbuild(t, fmt.Sprintf(`
 trap 'touch "%s";exit 2' INT
 
 >&3 echo invalid-json
@@ -202,7 +217,12 @@ done
 }
 
 func TestRunOSBuildWithBuildlogTerm(t *testing.T) {
-	restore := progress.MockOsbuildCmd(makeFakeOsbuild(t, `
+	restore := progress.MockEnoughPrivsForOsbuild(func() (bool, error) {
+		return true, nil
+	})
+	defer restore()
+
+	restore = progress.MockOsbuildCmd(makeFakeOsbuild(t, `
 echo osbuild-stdout-output
 >&2 echo osbuild-stderr-output
 
@@ -237,7 +257,11 @@ osbuild-stage-message
 }
 
 func TestRunOSBuildWithBuildlogVerbose(t *testing.T) {
-	restore := progress.MockOsbuildCmd(makeFakeOsbuild(t, `
+	restore := progress.MockEnoughPrivsForOsbuild(func() (bool, error) {
+		return true, nil
+	})
+	defer restore()
+	restore = progress.MockOsbuildCmd(makeFakeOsbuild(t, `
 echo osbuild-stdout-output
 >&2 echo osbuild-stderr-output
 `))
@@ -265,8 +289,13 @@ osbuild-stderr-output
 }
 
 func TestRunOSBuildCacheMaxSize(t *testing.T) {
+	restore := progress.MockEnoughPrivsForOsbuild(func() (bool, error) {
+		return true, nil
+	})
+	defer restore()
+
 	fakeOsbuildBinary := makeFakeOsbuild(t, `echo "$@" > "$0".cmdline`)
-	restore := progress.MockOsbuildCmd(fakeOsbuildBinary)
+	restore = progress.MockOsbuildCmd(fakeOsbuildBinary)
 	defer restore()
 
 	pbar, err := progress.New("debug")

--- a/pkg/progress/run.go
+++ b/pkg/progress/run.go
@@ -16,6 +16,7 @@ import (
 	"golang.org/x/sys/unix"
 
 	"github.com/osbuild/images/pkg/datasizes"
+	"github.com/osbuild/images/pkg/experimentalflags"
 	"github.com/osbuild/images/pkg/osbuild"
 )
 
@@ -76,6 +77,10 @@ func RunOSBuild(pb ProgressBar, manifest []byte, exports []string, opts *OSBuild
 		return fmt.Errorf("cannot check priviledges: %w", err)
 	}
 	if !enoughPrivs {
+		if experimentalflags.Bool("supermin") {
+			fmt.Fprintf(os.Stderr, "WARNING: using experimental supermin to build\n")
+			return runOSBuildWithSupermin(pb, manifest, exports, opts)
+		}
 		return fmt.Errorf("not enough priviledges: must be root with CAP_SYS_ADMIN")
 	}
 

--- a/pkg/progress/run.go
+++ b/pkg/progress/run.go
@@ -71,6 +71,11 @@ func RunOSBuild(pb ProgressBar, manifest []byte, exports []string, opts *OSBuild
 	if opts == nil {
 		opts = &OSBuildOptions{}
 	}
+	if opts.StoreDir != "" {
+		if err := os.MkdirAll(opts.StoreDir, 0755); err != nil {
+			return fmt.Errorf("cannot create store dir: %w", err)
+		}
+	}
 
 	enoughPrivs, err := enoughPrivsForOsbuild()
 	if err != nil {

--- a/pkg/progress/run.go
+++ b/pkg/progress/run.go
@@ -34,6 +34,9 @@ type OSBuildOptions struct {
 // enoughPrivsForOsbuild() returns true if the current process does
 // has enough priviledges to run osbuild
 var enoughPrivsForOsbuild = func() (bool, error) {
+	if experimentalflags.Bool("skip-priv-checks") {
+		return true, nil
+	}
 	tmpdir, err := os.MkdirTemp("", "ibcli-priv-check")
 	if err != nil {
 		return false, err

--- a/pkg/progress/run.go
+++ b/pkg/progress/run.go
@@ -1,0 +1,204 @@
+package progress
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"strings"
+	"sync"
+	"syscall"
+
+	"github.com/sirupsen/logrus"
+
+	"github.com/osbuild/images/pkg/datasizes"
+	"github.com/osbuild/images/pkg/osbuild"
+)
+
+type OSBuildOptions struct {
+	StoreDir  string
+	OutputDir string
+	ExtraEnv  []string
+
+	// BuildLog writes the osbuild output to the given writer
+	BuildLog io.Writer
+
+	CacheMaxSize int64
+}
+
+// XXX: merge variant back into images/pkg/osbuild/osbuild-exec.go
+// or into a new pkg/osbuild{,/}run/run.go
+func RunOSBuild(pb ProgressBar, manifest []byte, exports []string, opts *OSBuildOptions) error {
+	if opts == nil {
+		opts = &OSBuildOptions{}
+	}
+
+	// To keep maximum compatibility keep the old behavior to run osbuild
+	// directly and show all messages unless we have a "real" progress bar.
+	//
+	// This should ensure that e.g. "podman bootc" keeps working as it
+	// is currently expecting the raw osbuild output. Once we double
+	// checked with them we can remove the runOSBuildNoProgress() and
+	// just run with the new runOSBuildWithProgress() helper.
+	switch pb.(type) {
+	case *terminalProgressBar, *debugProgressBar:
+		return runOSBuildWithProgress(pb, manifest, exports, opts)
+	default:
+		return runOSBuildNoProgress(pb, manifest, exports, opts)
+	}
+}
+
+func newOsbuildCmd(manifest []byte, exports []string, opts *OSBuildOptions) *exec.Cmd {
+	cacheMaxSize := int64(20 * datasizes.GiB)
+	if opts.CacheMaxSize != 0 {
+		cacheMaxSize = opts.CacheMaxSize
+	}
+	cmd := exec.Command(
+		osbuildCmd,
+		"--store", opts.StoreDir,
+		"--output-directory", opts.OutputDir,
+		fmt.Sprintf("--cache-max-size=%v", cacheMaxSize),
+		"-",
+	)
+	for _, export := range exports {
+		cmd.Args = append(cmd.Args, "--export", export)
+	}
+	cmd.Env = append(os.Environ(), opts.ExtraEnv...)
+	cmd.Stdin = bytes.NewBuffer(manifest)
+	return cmd
+}
+
+func runOSBuildNoProgress(pb ProgressBar, manifest []byte, exports []string, opts *OSBuildOptions) error {
+	var stdout, stderr io.Writer
+
+	var writeMu sync.Mutex
+	if opts.BuildLog == nil {
+		// No external build log requested and we won't need an
+		// internal one because all output goes directly to
+		// stdout/stderr. This is for maximum compatibility with
+		// the existing bootc-image-builder in "verbose" mode
+		// where stdout, stderr come directly from osbuild.
+		stdout = osStdout()
+		stderr = osStderr()
+	} else {
+		// There is a slight wrinkle here: when requesting a
+		// buildlog we can no longer write to separate
+		// stdout/stderr streams without being racy and give
+		// potential out-of-order output (which is very bad
+		// and confusing in a log). The reason is that if
+		// cmd.Std{out,err} are different "go" will start two
+		// go-routine to monitor/copy those are racy when both
+		// stdout,stderr output happens close together
+		// (TestRunOSBuildWithBuildlog demos that). We cannot
+		// have our cake and eat it so here we need to combine
+		// osbuilds stderr into our stdout.
+		mw := newSyncedWriter(&writeMu, io.MultiWriter(osStdout(), opts.BuildLog))
+		stdout = mw
+		stderr = mw
+	}
+
+	cmd := newOsbuildCmd(manifest, exports, opts)
+	cmd.Stdout = stdout
+	cmd.Stderr = stderr
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("error running osbuild: %w", err)
+	}
+	return nil
+}
+
+var osbuildCmd = "osbuild"
+
+func runOSBuildWithProgress(pb ProgressBar, manifest []byte, exports []string, opts *OSBuildOptions) (err error) {
+	rp, wp, err := os.Pipe()
+	if err != nil {
+		return fmt.Errorf("cannot create pipe for osbuild: %w", err)
+	}
+	defer rp.Close()
+	defer wp.Close()
+
+	cmd := newOsbuildCmd(manifest, exports, opts)
+	cmd.Args = append(cmd.Args, "--monitor=JSONSeqMonitor")
+	cmd.Args = append(cmd.Args, "--monitor-fd=3")
+
+	var stdio bytes.Buffer
+	var mw, buildLog io.Writer
+	var writeMu sync.Mutex
+	if opts.BuildLog != nil {
+		mw = newSyncedWriter(&writeMu, io.MultiWriter(&stdio, opts.BuildLog))
+		buildLog = newSyncedWriter(&writeMu, opts.BuildLog)
+	} else {
+		mw = &stdio
+		buildLog = io.Discard
+	}
+
+	cmd.Stdout = mw
+	cmd.Stderr = mw
+	cmd.ExtraFiles = []*os.File{wp}
+
+	osbuildStatus := osbuild.NewStatusScanner(rp)
+	if err := cmd.Start(); err != nil {
+		return fmt.Errorf("error starting osbuild: %v", err)
+	}
+	wp.Close()
+	defer func() {
+		// Try to stop osbuild if we exit early, we are gentle
+		// here to give osbuild the chance to release its
+		// resources (like mounts in the buildroot). This is
+		// best effort only (but also a pretty uncommon error
+		// condition). If ProcessState is set the process has
+		// already exited and we have nothing to do.
+		if err != nil && cmd.Process != nil && cmd.ProcessState == nil {
+			sigErr := cmd.Process.Signal(syscall.SIGINT)
+			err = errors.Join(err, sigErr)
+		}
+	}()
+
+	var tracesMsgs []string
+	for {
+		st, err := osbuildStatus.Status()
+		if err != nil {
+			// This should never happen but if it does we try
+			// to be helpful. We need to exit here (and kill
+			// osbuild in the defer) or we would appear to be
+			// handing as cmd.Wait() would wait to finish but
+			// no progress or other message is reported. We
+			// can also not (in the general case) recover as
+			// the underlying osbuildStatus.scanner maybe in
+			// an unrecoverable state (like ErrTooBig).
+			return fmt.Errorf(`error parsing osbuild status, please report a bug and try with "--progress=verbose": %w`, err)
+		}
+		if st == nil {
+			break
+		}
+		i := 0
+		for p := st.Progress; p != nil; p = p.SubProgress {
+			if err := pb.SetProgress(i, p.Message, p.Done, p.Total); err != nil {
+				logrus.Warnf("cannot set progress: %v", err)
+			}
+			i++
+		}
+		// forward to user
+		if st.Message != "" {
+			pb.SetMessagef(st.Message)
+		}
+
+		// keep internal log for error reporting, forward to
+		// external build log
+		if st.Message != "" {
+			tracesMsgs = append(tracesMsgs, st.Message)
+			fmt.Fprintln(buildLog, st.Message)
+		}
+		if st.Trace != "" {
+			tracesMsgs = append(tracesMsgs, st.Trace)
+			fmt.Fprintln(buildLog, st.Trace)
+		}
+	}
+
+	if err := cmd.Wait(); err != nil {
+		return fmt.Errorf("error running osbuild: %w\nBuildLog:\n%s\nOutput:\n%s", err, strings.Join(tracesMsgs, "\n"), stdio.String())
+	}
+
+	return nil
+}

--- a/pkg/progress/run_test.go
+++ b/pkg/progress/run_test.go
@@ -1,0 +1,16 @@
+package progress_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/osbuild/image-builder-cli/pkg/progress"
+)
+
+func TestEnoughPrivsSmoke(t *testing.T) {
+	enoughPrivs, err := progress.EnoughPrivsForOsbuild()
+	assert.NoError(t, err)
+	assert.Equal(t, enoughPrivs, os.Getuid() == 0)
+}

--- a/pkg/progress/supermin.go
+++ b/pkg/progress/supermin.go
@@ -233,13 +233,6 @@ func runOSBuildWithSupermin(pbar ProgressBar, manifest []byte, exports []string,
 		return err
 	}
 
-	// XXX: haaaaaaaaaaaaaaaaaaack, we cannot write to the root owned
-	// /var/cache/image-builder otherwise
-	if os.Getuid() != 0 {
-		opts.StoreDir = ".store"
-		os.MkdirAll(".store", 0755)
-	}
-
 	// then we can run osbuild inside supermin
 	if err := os.MkdirAll(opts.OutputDir, 0755); err != nil {
 		return err

--- a/pkg/progress/supermin.go
+++ b/pkg/progress/supermin.go
@@ -1,0 +1,288 @@
+package progress
+
+import (
+	"archive/tar"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"syscall"
+	"time"
+
+	"github.com/osbuild/image-builder-cli/pkg/util"
+)
+
+var superminInitScriptFmt = `#!/bin/sh
+# inspired by https://github.com/coreos/coreos-assembler/blob/main/src/supermin-init-prelude.sh
+# we need less because osbuild does most of its work via buildroots
+
+set -e
+
+export PATH=/usr/sbin:/usr/bin:/sbin:/bin
+
+mount -t proc /proc /proc
+mount -t sysfs /sys /sys
+mount -t cgroup2 cgroup2 -o rw,nosuid,nodev,noexec,relatime,seclabel,nsdelegate,memory_recursiveprot /sys/fs/cgroup
+mount -t devtmpfs devtmpfs /dev
+
+# auto-reboot on kernel panic (e.g. if anything in this script dies)
+echo 1 > /proc/sys/kernel/panic
+
+# this is also normally set up by systemd in early boot
+ln -s /proc/self/fd/0 /dev/stdin
+ln -s /proc/self/fd/1 /dev/stdout
+ln -s /proc/self/fd/2 /dev/stderr
+
+# need /dev/shm for podman
+mkdir -p /dev/shm
+mount -t tmpfs tmpfs /dev/shm
+
+# osbuild needs /run
+mkdir -p /run
+mount -t tmpfs tmpfs /run
+
+### from here on we diverge from the above core-assembler script
+
+# ensure network
+/usr/sbin/dhclient eth0
+
+# central for osbuild
+mknod /dev/loop-control c 10 237
+
+# map in the host /output dir, virtiofsd support uid remapping so this
+# should be fine
+mkdir -p /output
+mount -t virtiofs osbuild_output /output
+
+# We cannot put the host osbuild "store" on our /store dir even with
+# virtiofsd as there will be issues with uid remapping and selinux
+# labels.
+mkdir -p /host/store
+mount -t virtiofs osbuild_store /host/store
+# rsync/cp the caches so that our build is faster
+echo "Populate /store from host"
+mkdir /store
+rsync -a --exclude=./tmp /host/store/ /store
+
+# fetch/cache sources first so that the host cache gets updated
+echo "Fetching sources"
+osbuild \
+  --cache /store \
+  /output/manifest.json
+# rsync
+rsync -a --exclude=./tmp /store/ /host/store
+
+echo "Running osbuild"
+osbuild \
+  --export %s \
+  --output-directory /output \
+  --cache /store \
+  /output/manifest.json
+
+# trigger clean shutdown via sysreq
+echo _suo > /proc/sysrq-trigger
+# shutdown is async so we need to sleep here or PID=0 dies
+sleep 999
+`
+
+func addInitTar(superminDir, superminInitScript string) error {
+	initTarF, err := os.Create(filepath.Join(superminDir, "init.tgz"))
+	if err != nil {
+		return err
+	}
+	defer initTarF.Close()
+	initTar := tar.NewWriter(initTarF)
+	defer initTar.Close()
+	if err := initTar.WriteHeader(&tar.Header{
+		Name: "init",
+		Size: int64(len(superminInitScript)),
+		Mode: 0755,
+	}); err != nil {
+		return err
+	}
+	if _, err := initTar.Write([]byte(superminInitScript)); err != nil {
+		return err
+	}
+	return nil
+}
+
+func superminPrepare(prepareDir, export string) error {
+	superminInitScript := fmt.Sprintf(superminInitScriptFmt, export)
+
+	// prepare supermin
+	err := util.RunCmdSync(
+		"supermin", "--prepare", "--use-installed",
+		// fundamental
+		"util-linux",
+		// convenient
+		"rsync",
+		// basic networking
+		"ca-certificates", "dhcp-client", "iproute",
+		// loop-device support
+		"kernel-modules",
+		// osbuild and friends
+		"osbuild", "osbuild-depsolve-dnf", "osbuild-lvm2", "osbuild-luks2", "osbuild-ostree",
+		// lvm
+		"lvm2",
+		// target"
+		"-o", prepareDir,
+	)
+	if err != nil {
+		return fmt.Errorf("supermin prepare failed: %w", err)
+	}
+	if err := addInitTar(prepareDir, superminInitScript); err != nil {
+		return err
+	}
+	return nil
+}
+
+func superminBuild(prepareDir, buildDir string) error {
+	err := util.RunCmdSync(
+		"supermin",
+		"--build", prepareDir,
+		// XXX: what is the right size?
+		"--size", "40G",
+		"-f", "ext2",
+		"-o", buildDir,
+	)
+	if err != nil {
+		return fmt.Errorf("supermin-build failed: %w", err)
+	}
+	return nil
+}
+
+func setupVirtiofsd(tmpDir, outputDir, storeDir string) (func(), error) {
+	var cmds []*exec.Cmd
+	var cleanupFunc = func() {
+		for _, cmd := range cmds {
+			if cmd != nil && cmd.Process != nil {
+				cmd.Process.Kill()
+			}
+		}
+	}
+
+	for _, mnt := range []struct {
+		path, tag string
+	}{
+		{outputDir, "output"},
+		{storeDir, "store"},
+	} {
+		socketPath := filepath.Join(tmpDir, fmt.Sprintf("vfsd_%s.sock", mnt.tag))
+		var args []string
+		// run virtiofsd in user namespace if non-root to make
+		// chown() and friends inside the VM work
+		if os.Getuid() != 0 {
+			args = append(args, "podman", "unshare", "--")
+		}
+		// if this runs as root we will be inside a unprivileged
+		// container so we need won't be able to do most of the
+		// sandboxing (e.g. setfcap)
+		args = append(args, "/usr/libexec/virtiofsd")
+		args = append(args, []string{
+			"--sandbox=none",
+			"--seccomp=none",
+			// workaround https://gitlab.com/virtio-fs/virtiofsd/-/merge_requests/197
+			"--modcaps=-mknod:-setfcap",
+			"--socket-path", socketPath,
+			"--shared-dir", mnt.path,
+		}...)
+		cmd := exec.Command(args[0], args[1:]...)
+		cmd.SysProcAttr = &syscall.SysProcAttr{
+			Pdeathsig: syscall.SIGTERM,
+		}
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stderr
+		if err := cmd.Start(); err != nil {
+			cleanupFunc()
+			return nil, err
+		}
+		cmds = append(cmds, cmd)
+	}
+	// XXX: wait for socket to appear
+	time.Sleep(2 * time.Second)
+
+	return cleanupFunc, nil
+}
+
+func runOSBuildWithSupermin(pbar ProgressBar, manifest []byte, exports []string, opts *OSBuildOptions) error {
+	// XXX: add support for progress via e.g. a virtio serial port
+	// that the osbuld output is piped to
+	pbar.Stop()
+	fmt.Fprintf(os.Stderr, "Running osbuild in supermin\n")
+
+	if _, err := os.Stat("/dev/kvm"); err != nil {
+		return fmt.Errorf("cannot use supermin without /dev/kvm: %w", err)
+	}
+	if len(exports) != 1 {
+		return fmt.Errorf("only a single export supported right now")
+	}
+
+	superminTmp, err := os.MkdirTemp("/var/tmp", "supermin")
+	if err != nil {
+		return err
+	}
+	defer os.RemoveAll(superminTmp)
+
+	// we need to prepare and then build supermin
+	prepareDir := filepath.Join(superminTmp, "prepare")
+	if err := superminPrepare(prepareDir, exports[0]); err != nil {
+		return err
+	}
+	runDir := filepath.Join(superminTmp, "run")
+	if err := superminBuild(prepareDir, runDir); err != nil {
+		return err
+	}
+
+	// XXX: haaaaaaaaaaaaaaaaaaack, we cannot write to the root owned
+	// /var/cache/image-builder otherwise
+	if os.Getuid() != 0 {
+		opts.StoreDir = ".store"
+		os.MkdirAll(".store", 0755)
+	}
+
+	// then we can run osbuild inside supermin
+	if err := os.MkdirAll(opts.OutputDir, 0755); err != nil {
+		return err
+	}
+	manifestPath := filepath.Join(opts.OutputDir, "manifest.json")
+	if err := os.WriteFile(manifestPath, manifest, 0644); err != nil {
+		return err
+	}
+	defer os.Remove(manifestPath)
+
+	// map /output, /store into VM
+	cleanup, err := setupVirtiofsd(superminTmp, opts.OutputDir, opts.StoreDir)
+	if err != nil {
+		return err
+	}
+	defer cleanup()
+
+	return util.RunCmdSync(
+		"qemu-kvm",
+		"-nodefaults", "-nographic",
+		"-accel", "kvm",
+		"-cpu", "host",
+		"-m", "4G",
+		// exit on reboot, we need this to catch crashes in the init
+		// shell script
+		"-no-reboot",
+		// XXX: see colins osbuildbootc/cosa for $arch specific setup
+		// for qemu
+		"-netdev", "user,id=eth0",
+		"-device", "virtio-net-pci,netdev=eth0",
+		"-object", "memory-backend-memfd,id=mem,size=4G,share=on",
+		"-numa", "node,memdev=mem",
+		// supermin generates those
+		"-kernel", filepath.Join(runDir, "kernel"),
+		"-initrd", filepath.Join(runDir, "initrd"),
+		// virtiosfds stuff
+		"-chardev", "socket,id=char0,path="+superminTmp+"/vfsd_output.sock",
+		"-device", "vhost-user-fs-pci,queue-size=1024,chardev=char0,tag=osbuild_output",
+		"-chardev", "socket,id=char1,path="+superminTmp+"/vfsd_store.sock",
+		"-device", "vhost-user-fs-pci,queue-size=1024,chardev=char1,tag=osbuild_store",
+		// XXX: see colins osbuildbootc/cosa for $arch options
+		"-hda", filepath.Join(runDir, "root"),
+		"-serial", "stdio",
+		"-append", "console=ttyS0 quiet root=/dev/sda",
+	)
+}

--- a/pkg/progress/supermin.go
+++ b/pkg/progress/supermin.go
@@ -82,13 +82,15 @@ osbuild \
   --output-directory /output \
   --cache /store \
   /output/manifest.json
+sync
 
 echo "" > /output/%s
 
 # trigger clean shutdown via sysreq
 echo _suo > /proc/sysrq-trigger
 # shutdown is async so we need to sleep here or PID=0 dies
-sleep 999
+sleep 300
+echo "shutdown takes unusually long, please report as a bug"
 `
 
 func addInitTar(superminDir, superminInitScript string) error {

--- a/pkg/progress/supermin_test.go
+++ b/pkg/progress/supermin_test.go
@@ -1,0 +1,48 @@
+package progress_test
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/osbuild/image-builder-cli/pkg/progress"
+)
+
+func TestWaitForFilesFile(t *testing.T) {
+	tmpdir := t.TempDir()
+
+	// trivial case, no file appears, we error
+	start := time.Now()
+	canary1 := filepath.Join(tmpdir, "f1.txt")
+	err := progress.WaitForFiles(200*time.Millisecond, canary1)
+	assert.EqualError(t, err, fmt.Sprintf("files missing after 200ms: [%s]", canary1))
+	// ensure we waited untilthe timeout
+	assert.True(t, time.Since(start) >= 200*time.Millisecond)
+
+	// trivial case, file is already there before we wait
+	err = os.WriteFile(canary1, nil, 0644)
+	assert.NoError(t, err)
+	// use an absurd high time to ensure test timeouts if we would
+	// wait a long time here
+	err = progress.WaitForFiles(1*time.Hour, canary1)
+	assert.NoError(t, err)
+
+	// new file appears after 100ms
+	canary2 := filepath.Join(tmpdir, "f2.txt")
+	start = time.Now()
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		err := os.WriteFile(canary2, nil, 0644)
+		assert.NoError(t, err)
+	}()
+	err = progress.WaitForFiles(1*time.Hour, canary1, canary2)
+	assert.NoError(t, err)
+	assert.True(t, time.Since(start) >= 100*time.Millisecond)
+	// it should take 100-200msec to get the file but to avoid
+	// races in heavy loaded CI VMs we are conservative here
+	assert.True(t, time.Since(start) <= time.Second)
+}


### PR DESCRIPTION
This PR adds support for building images without root or a privileged container using the "supermin" binary. It will require access to /dev/kvm though to make the builds reasonably fast.

This is ready for review now, it will need followups to support supermin building in aarch64, s390x and ppc64le, Colin/Johnathan and frieds in COSA did excellent work here so this is hopefully mostly busywork (testing it will be tricky though).

Another followup will be needed to add proper functional tests for supermin, I have a WIP branch in https://github.com/osbuild/image-builder-cli/compare/main...mvo5:supermin-cleanup-test?expand=1 for this but this PR is already quite large so I'm hesitant to make it even larger).

Kudos to cgwalters and jlebon for the excellent help and examples in https://github.com/osbuild/bootc-image-builder/issues/98

/jira-epic COMPOSER-2487

JIRA: [HMS-5955](https://issues.redhat.com/browse/HMS-5955)