### PR TITLE
main: `describe` auto-detect distro

### DIFF
--- a/cmd/image-builder/main.go
+++ b/cmd/image-builder/main.go
@@ -352,6 +352,12 @@ func cmdDescribeImg(cmd *cobra.Command, args []string) error {
 	if archStr == "" {
 		archStr = arch.Current().String()
 	}
+
+	distroStr, err = findDistro(distroStr, "")
+	if err != nil {
+		return err
+	}
+
 	imgTypeStr := args[0]
 	res, err := getOneImage(distroStr, imgTypeStr, archStr, &repoOptions{DataDir: dataDir})
 	if err != nil {


### PR DESCRIPTION
Other commands such as `manifest`, and `build` auto detect the distribution if none is given. `describe` is the odd one out that requires `--distro`. Let's also autoselect there.