### PR TITLE
main: `describe` non-hidden

### DIFF
--- a/cmd/image-builder/main.go
+++ b/cmd/image-builder/main.go
@@ -460,7 +460,7 @@ operating systems like Fedora, CentOS and RHEL with easy customizations support.
 		RunE:         cmdDescribeImg,
 		SilenceUsage: true,
 		Args:         cobra.ExactArgs(1),
-		Hidden:       true,
+		Hidden:       false,
 		Aliases:      []string{"describe-image"},
 	}
 	describeImgCmd.Flags().String("arch", "", `use the different architecture`)


### PR DESCRIPTION
The describe format has become quite useful, we should list it in the help page.

---

@mvo5 mentioned this in another PR, perhaps together with #190 it'd be nice to have this subcommand listed in `help`.