### PR TITLE
ci: release into epel-9-next

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -30,19 +30,19 @@ jobs:
     dist_git_branches:
       - fedora-branched  # rawhide updates are created automatically
       - epel-10
-      - epel-9
+      - epel-9-next
   - job: koji_build
     trigger: commit
     dist_git_branches:
       - fedora-all
       - epel-10
-      - epel-9
+      - epel-9-next
   - job: propose_downstream
     trigger: release
     dist_git_branches:
       - fedora-all
       - epel-10
-      - epel-9
+      - epel-9-next
   - job: copr_build
     trigger: pull_request
     targets: &build_targets


### PR DESCRIPTION
Instead of directly releasing to epel-9 we should release into epel-9-next and do manual merges/releases when/if RHEL and/or CentOS catch up with our dependencies.