### PR TITLE
test: fix missing conversion of a test blueprint to toml

### DIFF
--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -25,6 +25,8 @@ jobs:
         run: |
           # we have the same build-deps as the images library
           curl -sL https://raw.githubusercontent.com/osbuild/images/refs/heads/main/test/scripts/install-dependencies | bash
+          # we also need createrepo_c
+          dnf install -y createrepo_c
       - name: Build
         run: go build -v ./...
       - name: Test

--- a/cmd/image-builder/main_test.go
+++ b/cmd/image-builder/main_test.go
@@ -751,11 +751,10 @@ func TestManifestExtraRepo(t *testing.T) {
 	err = exec.Command("createrepo_c", localRepoDir).Run()
 	assert.NoError(t, err)
 
-	pkgHelloBlueprint := `{
-          "packages": [
-            {"name":"dummy"}
-          ]
-        }`
+	pkgHelloBlueprint := `
+        [[packages]]
+        name = "dummy"
+`
 	restore := main.MockOsArgs([]string{
 		"manifest",
 		"qcow2",


### PR DESCRIPTION
This commit fixes the issue that a test blueprint was not converted from json to TOML. This was not caught in CI apparently because our test container misses createrepo_c.