### PR TITLE
main: add new `--registrations` options

### DIFF
--- a/cmd/image-builder/export_test.go
+++ b/cmd/image-builder/export_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/osbuild/images/pkg/cloud"
 	"github.com/osbuild/images/pkg/cloud/awscloud"
+	"github.com/osbuild/images/pkg/manifestgen"
 	"github.com/osbuild/images/pkg/reporegistry"
 )
 
@@ -69,5 +70,13 @@ func MockAwscloudNewUploader(f func(string, string, string, *awscloud.UploaderOp
 	awscloudNewUploader = f
 	return func() {
 		awscloudNewUploader = saved
+	}
+}
+
+func MockManifestgenDepsolver(new manifestgen.DepsolveFunc) (restore func()) {
+	saved := manifestgenDepsolver
+	manifestgenDepsolver = new
+	return func() {
+		manifestgenDepsolver = saved
 	}
 }


### PR DESCRIPTION
This new flag allows to add a file with registration data. This is meant to eventually hold all sort of registrations like ansible or satelite but initially only contains the redhat subscription. Currently only JSON is supported.

It looks like:
```json
{
  "redhat": {
    "subscription": {
      "activation_key": "ak_123",
      "organization": "org_123",
      "server_url": "server_url_123",
      "base_url": "base_url_123",
      "insights": true,
      "rhc": true,
      "proxy": "proxy_123"
    }
  }
}
```

This is not part of the blueprint (today) because its more ephemeral than the things we usually put into the blueprint.

This allows us to build images that are immediately registered. It also keeps our options open in the future. If we move to a new blueprint format where we support multiple blueprints and also ephemeral data like this the "registrations" flag just becomes an alias for "--blueprint".

[edit: it seems people like the idea so I dropped the RFC and draft from it]