### PR TITLE
manifest: handle "close()" errors in sbomWriter()

### DIFF
--- a/cmd/image-builder/manifest.go
+++ b/cmd/image-builder/manifest.go
@@ -39,11 +39,13 @@ func sbomWriter(outputDir, filename string, content io.Reader) error {
 	if err != nil {
 		return err
 	}
+	// ensure we do not leak FDs if the function returns prematurely
 	defer f.Close()
+
 	if _, err := io.Copy(f, content); err != nil {
 		return err
 	}
-	return nil
+	return f.Close()
 }
 
 func generateManifest(dataDir string, extraRepos []string, img *imagefilter.Result, output io.Writer, depsolveWarningsOutput io.Writer, opts *manifestOptions) error {


### PR DESCRIPTION
This commit adds error handling for the `f.Close()` errors when we write the SBOM. Errors on close for RW fds are rare but we should handle them so we return the result of `f.Close()` now when returning in sbomWriter(). We still keep the `defer f.Close()` to ensure we do not leak file descriptors when e.g. `io.Copy()` fails. In the "happy" case f is closed without an error and then the defer f.Close() runs and will error with "ErrClosed" but we can ignore that.

An alternative implementaiton might be:
```golang
func sbomWriter(outputDir, filename string, content io.Reader) (err error) {
	...
	f, err := os.Create(p)
	if err != nil {
		return err
	}
	defer func() { err = errors.Join(f.Close(), err) }()
	...
	return nil
}
```
no super strong opinion here.

Thanks to Flo for finding this issues!

[releated to https://github.com/osbuild/bootc-image-builder/pull/891]