### PR TITLE
manifest: use Sync instead of Close

### DIFF
--- a/cmd/image-builder/manifest.go
+++ b/cmd/image-builder/manifest.go
@@ -41,13 +41,13 @@ func sbomWriter(outputDir, filename string, content io.Reader) error {
 	if err != nil {
 		return err
 	}
-	// ensure we do not leak FDs if the function returns prematurely
 	defer f.Close()
 
 	if _, err := io.Copy(f, content); err != nil {
 		return err
 	}
-	return f.Close()
+
+	return f.Sync()
 }
 
 // used in tests


### PR DESCRIPTION
I missed the discussion in https://github.com/osbuild/image-builder-cli/pull/202 therefore I would like to file a counter-proposal. Generally I agree with the resolution, anonymous function is confusing because it builds on a quirky Go language feature, utility functions that issues a warning are not very helpful (who reads warnings) so the final code looks reasonable. There is one snag I do not like.

Calling `Close` twice is just not right, the second call is guaranteed to fail and while it is ignored thanks to `defer`, some warnings might end up in system journal or audit software for no apparent reason. Thus, I would like to suggest a slight change of the approach that is also recommended in the `close(2)` Linux man page - call `Sync` instead. It does the same thing as `Close` when it comes to return values, however, the code will not call `Close` twice. It also obviously issues a request to perform immediate fsync which is the only difference that can be seen as an advantage or disadvantage, but before discussing that I would like to point out that the main goal is a cleaner code. In our use case, I see it as a slight advantage.

I like this approach more because `Sync` is only available for `File` (or similar) types, this pattern will literally not compile if you have a buffer, a string writer or something similar, for example when dealing with a HTTP request/response body variable. This could possibly prevent misuse of this pattern in other cases.

Here is an excerpt from the man page:

```
A careful programmer will check the return value of close(), since
it is quite possible that errors on a previous write(2) operation
are reported only on the final close() that releases the open file
description.  Failing to check the return value when closing a
file may lead to silent loss of data.  This can especially be
observed with NFS and with disk quota.

Note, however, that a failure return should be used only for
diagnostic purposes (i.e., a warning to the application that there
may still be I/O pending or there may have been failed I/O) or
remedial purposes (e.g., writing the file once more or creating a
backup).

Retrying the close() after a failure return is the wrong thing to
do, since this may cause a reused file descriptor from another
thread to be closed.  This can occur because the Linux kernel
always releases the file descriptor early in the close operation,
freeing it for reuse; the steps that may return an error, such as
flushing data to the filesystem or device, occur only later in the
close operation.

Many other implementations similarly always close the file
descriptor (except in the case of EBADF, meaning that the file
descriptor was invalid) even if they subsequently report an error
on return from close().  POSIX.1 is currently silent on this
point, but there are plans to mandate this behavior in the next
major release of the standard.

A careful programmer who wants to know about I/O errors may
precede close() with a call to fsync(2).
```