### PR TITLE
refactor: use standard logger instead of logrus

### DIFF
--- a/cmd/image-builder/main_test.go
+++ b/cmd/image-builder/main_test.go
@@ -14,7 +14,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -29,11 +28,6 @@ import (
 	"github.com/osbuild/image-builder-cli/internal/testutil"
 	"github.com/osbuild/images/pkg/arch"
 )
-
-func init() {
-	// silence logrus by default, it is quite verbose
-	logrus.SetLevel(logrus.WarnLevel)
-}
 
 func TestListImagesNoArguments(t *testing.T) {
 	restore := main.MockNewRepoRegistry(testrepos.New)

--- a/internal/olog/package.go
+++ b/internal/olog/package.go
@@ -1,0 +1,8 @@
+// Package olog provides a simple wrapper around the standard log package
+// variable so logging statements are shorter. Instead of pkg.Logger.Printf one
+// can simply write olog.Printf.
+//
+// The name stands for "optional logger" because the output can be disabled by
+// setting the logger to nil or providing io.Discard as the output. This is
+// useful for user-configurable logging (e.g. --verbose flags for CLI apps).
+package olog

--- a/internal/olog/proxy.go
+++ b/internal/olog/proxy.go
@@ -1,0 +1,83 @@
+package olog
+
+import "io"
+
+// Print is a proxy for log.Print.
+func Print(v ...any) {
+	Default().Print(v...)
+}
+
+// Printf is a proxy for log.Printf.
+func Printf(format string, v ...any) {
+	Default().Printf(format, v...)
+}
+
+// Println is a proxy for log.Println.
+func Println(v ...any) {
+	Default().Println(v...)
+}
+
+// Fatal is a proxy for log.Fatal.
+func Fatal(v ...any) {
+	Default().Fatal(v...)
+}
+
+// Fatalf is a proxy for log.Fatalf.
+func Fatalf(format string, v ...any) {
+	Default().Fatalf(format, v...)
+}
+
+// Fatalln is a proxy for log.Fatalln.
+func Fatalln(v ...any) {
+	Default().Fatalln(v...)
+}
+
+// Panic is a proxy for log.Panic.
+func Panic(v ...any) {
+	Default().Panic(v...)
+}
+
+// Panicf is a proxy for log.Panicf.
+func Panicf(format string, v ...any) {
+	Default().Panicf(format, v...)
+}
+
+// Panicln is a proxy for log.Panicln.
+func Panicln(v ...any) {
+	Default().Panicln(v...)
+}
+
+// Writer is a proxy for log.Writer.
+func Writer() io.Writer {
+	return Default().Writer()
+}
+
+// Output is a proxy for log.Output.
+func Output(calldepth int, s string) error {
+	return Default().Output(calldepth+1, s)
+}
+
+// SetOutput is a proxy for log.SetOutput.
+func SetOutput(w io.Writer) {
+	Default().SetOutput(w)
+}
+
+// Flags is a proxy for log.Flags.
+func Flags() int {
+	return Default().Flags()
+}
+
+// SetFlags is a proxy for log.SetFlags.
+func SetFlags(flag int) {
+	Default().SetFlags(flag)
+}
+
+// Prefix is a proxy for log.Prefix.
+func Prefix() string {
+	return Default().Prefix()
+}
+
+// SetPrefix is a proxy for log.SetPrefix.
+func SetPrefix(prefix string) {
+	Default().SetPrefix(prefix)
+}

--- a/internal/olog/var.go
+++ b/internal/olog/var.go
@@ -1,0 +1,30 @@
+package olog
+
+import (
+	"io"
+	"log"
+	"sync/atomic"
+)
+
+var logger atomic.Pointer[log.Logger]
+
+func init() {
+	SetDefault(nil)
+}
+
+// SetDefault sets the default logger to the provided logger. When nil is passed,
+// the default logger is set to a no-op logger that discards all log messages.
+func SetDefault(l *log.Logger) {
+	if l == nil {
+		logger.Store(log.New(io.Discard, "", 0))
+		return
+	}
+
+	logger.Store(l)
+}
+
+// Default returns the default logger. If no logger has been set, it returns a
+// no-op logger that discards all log messages.
+func Default() *log.Logger {
+	return logger.Load()
+}

--- a/pkg/progress/progress.go
+++ b/pkg/progress/progress.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log"
 	"os"
 	"os/exec"
 	"strings"
@@ -14,7 +15,6 @@ import (
 
 	"github.com/cheggaaa/pb/v3"
 	"github.com/mattn/go-isatty"
-	"github.com/sirupsen/logrus"
 
 	"github.com/osbuild/images/pkg/datasizes"
 	"github.com/osbuild/images/pkg/osbuild"
@@ -241,7 +241,7 @@ func (b *terminalProgressBar) Stop() {
 		// I cannot think of how this could happen, i.e. why
 		// closing would not work but lets be conservative -
 		// without a timeout we hang here forever
-		logrus.Warnf("no progress channel shutdown after 1sec")
+		log.Printf("WARNING: no progress channel shutdown after 1sec")
 	}
 	b.shutdownCh = nil
 	// This should never happen but be paranoid, this should
@@ -479,7 +479,7 @@ func runOSBuildWithProgress(pb ProgressBar, manifest []byte, exports []string, o
 		i := 0
 		for p := st.Progress; p != nil; p = p.SubProgress {
 			if err := pb.SetProgress(i, p.Message, p.Done, p.Total); err != nil {
-				logrus.Warnf("cannot set progress: %v", err)
+				log.Printf("WARNING: cannot set progress: %v", err)
 			}
 			i++
 		}

--- a/pkg/setup/setup.go
+++ b/pkg/setup/setup.go
@@ -2,6 +2,7 @@ package setup
 
 import (
 	"fmt"
+	"log"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -9,8 +10,6 @@ import (
 	"strings"
 
 	"golang.org/x/sys/unix"
-
-	"github.com/sirupsen/logrus"
 
 	"github.com/osbuild/image-builder-cli/pkg/podmanutil"
 	"github.com/osbuild/image-builder-cli/pkg/util"
@@ -136,7 +135,7 @@ func validateCanRunTargetArch(targetArch string) error {
 		// we could error here but in principle with a working qemu-user
 		// any arch should work so let's just warn. the common case
 		// (arm64/amd64) is covered properly
-		logrus.Warningf("cannot check architecture support for %v: no canary binary found", targetArch)
+		log.Printf("WARNING: cannot check architecture support for %v: no canary binary found", targetArch)
 		return nil
 	}
 	output, err := exec.Command(canaryCmd).CombinedOutput()

--- a/pkg/setup/setup_test.go
+++ b/pkg/setup/setup_test.go
@@ -3,12 +3,12 @@ package setup_test
 import (
 	"bytes"
 	"fmt"
+	"log"
 	"os"
 	"path/filepath"
 	"runtime"
 	"testing"
 
-	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/osbuild/image-builder-cli/pkg/setup"
@@ -23,11 +23,13 @@ func TestValidateCanRunTargetArchTrivial(t *testing.T) {
 
 func TestValidateCanRunTargetArchUnsupportedCanary(t *testing.T) {
 	var logbuf bytes.Buffer
-	logrus.SetOutput(&logbuf)
+	ow := log.Writer()
+	log.SetOutput(&logbuf)
+	defer log.SetOutput(ow)
 
 	err := setup.ValidateCanRunTargetArch("unsupported-arch")
 	assert.NoError(t, err)
-	assert.Contains(t, logbuf.String(), `level=warning msg="cannot check architecture support for unsupported-arch: no canary binary found"`)
+	assert.Contains(t, logbuf.String(), `cannot check architecture support for unsupported-arch: no canary binary found`)
 }
 
 func makeFakeBinary(t *testing.T, binary, content string) {
@@ -43,7 +45,9 @@ func makeFakeCanary(t *testing.T, content string) {
 
 func TestValidateCanRunTargetArchHappy(t *testing.T) {
 	var logbuf bytes.Buffer
-	logrus.SetOutput(&logbuf)
+	ow := log.Writer()
+	log.SetOutput(&logbuf)
+	defer log.SetOutput(ow)
 
 	makeFakeCanary(t, "#!/bin/sh\necho ok")
 

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -6,7 +6,7 @@ import (
 	"os/exec"
 	"strings"
 
-	"github.com/sirupsen/logrus"
+	"github.com/osbuild/image-builder-cli/internal/olog"
 )
 
 // IsMountpoint checks if the target path is a mount point
@@ -17,7 +17,7 @@ func IsMountpoint(path string) bool {
 // Synchronously invoke a command, propagating stdout and stderr
 // to the current process's stdout and stderr
 func RunCmdSync(cmdName string, args ...string) error {
-	logrus.Debugf("Running: %s %s", cmdName, strings.Join(args, " "))
+	olog.Printf("Running: %s %s", cmdName, strings.Join(args, " "))
 	cmd := exec.Command(cmdName, args...)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr


### PR DESCRIPTION
I would like to propose moving away from logrus in the image-builder-cli (and standalone CLI tools from composer and images as well). The library is in maintenance mode for quite a while and I believe it does not provide a good structured logging capabilities and API (log/slog is better) while for console logging it is an overkill. It was primarily designed to be structured logging library with some human-formatting features (Printf...).

Now, for services like crc/composer, I am currently working on replacing logrus with log/slog structured logging library which is part of Go. However, structured logging is not a great fit for CLI applications since its primary purpose is to machine-readable output (JSON) and although text formatters are available in the standard library, it is not best reading for humans. Example: time=2025-04-29 11:30 msg=Initializing osbuild

The question tho is what to replace logrus with, and what I would like to propose is a simple one: there is a log package in the standard library that is extremely simple. It basically only provides Print / Prinln / Printf plus Error/Panic counterparts which do the same but exits the program. There are no logging levels, because they do not make sense in the console UNIX apps context - programs should be silent by default and diagnostic output or errors should be printed to stderr. The standard logger in Go is configured to send all output to stderr actually. I like this simplicity. Also, the API is so clean and small that it is super easy to create a utility package that can provide multiple loggers with multiple "levels" and outputs if needed.

The initial version of the PR comes with a new package called `olog` (optional log) which stands for optional logger and it is a proxy to `log.Logger` that can be turned off or on depending on the `--verbose` option. While this could have been a simple variable somewhere in the code, its own package enables seamless and short use: `olog.Printf(...)` that nicely match `log.Printf(...)`.

My plan is to the similar PR in the `images` library with similar `olog` package (a copy is perhaps sufficient this API is stable). This way, the logging can be enabled, disabled or redirected from API users.