### PR TITLE
image-builder: fix cross-arch uploading

### DIFF
--- a/cmd/image-builder/main.go
+++ b/cmd/image-builder/main.go
@@ -477,6 +477,7 @@ operating systems like Fedora, CentOS and RHEL with easy customizations support.
 	uploadCmd.Flags().String("aws-ami-name", "", "name for the AMI in AWS (only for type=ami)")
 	uploadCmd.Flags().String("aws-bucket", "", "target S3 bucket name for intermediate storage when creating AMI (only for type=ami)")
 	uploadCmd.Flags().String("aws-region", "", "target region for AWS uploads (only for type=ami)")
+	uploadCmd.Flags().String("arch", "", "upload for the given architecture")
 	rootCmd.AddCommand(uploadCmd)
 
 	buildCmd := &cobra.Command{

--- a/cmd/image-builder/main.go
+++ b/cmd/image-builder/main.go
@@ -334,7 +334,8 @@ func cmdBuild(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	uploader, err := uploaderFor(cmd, res.ImgType.Name())
+	bootMode := res.ImgType.BootMode()
+	uploader, err := uploaderFor(cmd, res.ImgType.Name(), &bootMode)
 	if errors.Is(err, ErrUploadTypeUnsupported) || errors.Is(err, ErrUploadConfigNotProvided) {
 		err = nil
 	}

--- a/cmd/image-builder/main.go
+++ b/cmd/image-builder/main.go
@@ -335,7 +335,7 @@ func cmdBuild(cmd *cobra.Command, args []string) error {
 	}
 
 	bootMode := res.ImgType.BootMode()
-	uploader, err := uploaderFor(cmd, res.ImgType.Name(), &bootMode)
+	uploader, err := uploaderFor(cmd, res.ImgType.Name(), res.ImgType.Arch().Name(), &bootMode)
 	if errors.Is(err, ErrUploadTypeUnsupported) || errors.Is(err, ErrUploadConfigNotProvided) {
 		err = nil
 	}

--- a/cmd/image-builder/upload.go
+++ b/cmd/image-builder/upload.go
@@ -89,6 +89,16 @@ func uploaderForCmdAWS(cmd *cobra.Command, bootMode *platform.BootMode) (cloud.U
 	if err != nil {
 		return nil, err
 	}
+	if bootMode == nil {
+		// If unset, default to BOOT_HYBIRD which translated
+		// to "uefi-prefered" when registering the image.
+		// This should give us wide compatibility. Ideally
+		// we would introspect the image but we have no
+		// metadata there right now.
+		// XXX: move this into the "images" library itself?
+		bootModeHybrid := platform.BOOT_HYBRID
+		bootMode = &bootModeHybrid
+	}
 
 	var missing []string
 	requiredArgs := []string{"aws-ami-name", "aws-bucket", "aws-region"}
@@ -126,8 +136,6 @@ func cmdUpload(cmd *cobra.Command, args []string) error {
 	}
 
 	imagePath := args[0]
-	// XXX: we need a way to introspect the image for bootmode here
-	// and/or error if no bootmode is specified
 	uploader, err := uploaderFor(cmd, uploadTo, nil)
 	if err != nil {
 		return err

--- a/cmd/image-builder/upload.go
+++ b/cmd/image-builder/upload.go
@@ -84,6 +84,10 @@ func uploaderForCmdAWS(cmd *cobra.Command) (cloud.Uploader, error) {
 	if err != nil {
 		return nil, err
 	}
+	targetArch, err := cmd.Flags().GetString("arch")
+	if err != nil {
+		return nil, err
+	}
 
 	var missing []string
 	requiredArgs := []string{"aws-ami-name", "aws-bucket", "aws-region"}
@@ -103,8 +107,11 @@ func uploaderForCmdAWS(cmd *cobra.Command) (cloud.Uploader, error) {
 
 		return nil, fmt.Errorf("%w: %q", ErrMissingUploadConfig, missing)
 	}
+	opts := &awscloud.UploaderOptions{
+		TargetArch: targetArch,
+	}
 
-	return awscloudNewUploader(region, bucketName, amiName, nil)
+	return awscloudNewUploader(region, bucketName, amiName, opts)
 }
 
 func cmdUpload(cmd *cobra.Command, args []string) error {

--- a/cmd/image-builder/upload_test.go
+++ b/cmd/image-builder/upload_test.go
@@ -92,7 +92,8 @@ func TestUploadWithAWSMock(t *testing.T) {
 		assert.Equal(t, regionName, "aws-region-1")
 		assert.Equal(t, bucketName, "aws-bucket-2")
 		assert.Equal(t, amiName, "aws-ami-3")
-		assert.Equal(t, &awscloud.UploaderOptions{TargetArch: tc.expectedUploadArch}, uploadOpts)
+		expectedBootMode := platform.BOOT_HYBRID
+		assert.Equal(t, &awscloud.UploaderOptions{TargetArch: tc.expectedUploadArch, BootMode: &expectedBootMode}, uploadOpts)
 
 		assert.Equal(t, 0, fa.checkCalls)
 		assert.Equal(t, 1, fa.uploadAndRegisterCalls)

--- a/cmd/image-builder/upload_test.go
+++ b/cmd/image-builder/upload_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/osbuild/images/pkg/cloud"
 	"github.com/osbuild/images/pkg/cloud/awscloud"
+	"github.com/osbuild/images/pkg/platform"
 
 	main "github.com/osbuild/image-builder-cli/cmd/image-builder"
 	"github.com/osbuild/image-builder-cli/internal/testutil"
@@ -144,10 +145,12 @@ func TestBuildAndUploadWithAWSMock(t *testing.T) {
 
 	var regionName, bucketName, amiName string
 	var fa fakeAwsUploader
+	var uploadOpts *awscloud.UploaderOptions
 	restore := main.MockAwscloudNewUploader(func(region string, bucket string, ami string, opts *awscloud.UploaderOptions) (cloud.Uploader, error) {
 		regionName = region
 		bucketName = bucket
 		amiName = ami
+		uploadOpts = opts
 		return &fa, nil
 	})
 	defer restore()
@@ -178,6 +181,8 @@ func TestBuildAndUploadWithAWSMock(t *testing.T) {
 	assert.Equal(t, regionName, "aws-region-1")
 	assert.Equal(t, bucketName, "aws-bucket-2")
 	assert.Equal(t, amiName, "aws-ami-3")
+	expectedBootMode := platform.BOOT_HYBRID
+	assert.Equal(t, &awscloud.UploaderOptions{BootMode: &expectedBootMode}, uploadOpts)
 	assert.Equal(t, 1, fa.checkCalls)
 	assert.Equal(t, 1, fa.uploadAndRegisterCalls)
 	assert.Equal(t, "fake-img-raw\n", fa.uploadAndRegisterRead.String())


### PR DESCRIPTION
upload: try to auto-detect the upload arch from the filename

This is another convenience feature for the `image-builder upload`
command: when we do not know the target architecture try to
guess it from the filename. This is not perfect but it will
help a lot of users and should be fine until the day we go
and inspect the image.

---

upload: warn the user if no `--arch` flag is passed on upload

This mitigates the issue that a `image-builder upload` command
currently does not know the target architecture of the image
it uploads.

---

upload: default to boot-mode `uefi-preferred` when unset

When using `image-builder upload --to=aws` we do not know
the bootmode. Ideally we would introspect the image for
the boot mode but that is not trivial right now.

So for now just default to platform.BOOT_HYBRID which
translated to `uefi-preferred` in the AWS API calls
which should offer the widest compatbility and should
fix the issue that aarch64 does not boot currently
when uploaded via ibcli.

---

bib: pass the boot-mode to AWS when doing combined
 build/upload

This commit passes the boot mode to AWS when doing a combined
build/upload. Here we know what boot mode to use and we can
pass it easily.

This also adds a "XXX" to think about how to handle what to
do when uploading a pre-existing image where we do not know
the boot mode.

---

image-builder: fix cross-arch uploading

This commit fixes the cross-arch uploading in the most simple
case by reading the `--arch` when `image-builder build --upload`
is used. Note that this is not a complete fix as it will not
take boot mode into account nor will it (by default) DTRT when
`image-builder upload` is used on a previously build images
for a different architecture.
