### PR TITLE
packit: rename epel9-next

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -30,7 +30,7 @@ jobs:
     dist_git_branches:
       - fedora-branched  # rawhide updates are created automatically
       - epel-10
-      - epel-9-next
+      - epel9-next
   - job: koji_build
     trigger: commit
     dist_git_branches:
@@ -42,7 +42,7 @@ jobs:
     dist_git_branches:
       - fedora-all
       - epel-10
-      - epel-9-next
+      - epel9-next
   - job: copr_build
     trigger: pull_request
     targets: &build_targets


### PR DESCRIPTION
We've had issues proposing downstream for epel9-next due to branch name failures. Let's see if this resolves that.

Should close/resolve #221 in the future.