### PR TITLE
GHA: add the common-stale-action

### DIFF
--- a/.github/workflows/stale-cleanup.yml
+++ b/.github/workflows/stale-cleanup.yml
@@ -1,0 +1,17 @@
+name: Mark and close stale issues and PRs
+
+on:  # yamllint disable-line rule:truthy
+  schedule:
+    - cron: '0 4 * * *'
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write  # needed to clean up the saved action state
+      issues: write
+      pull-requests: write
+    steps:
+      - uses: osbuild/common-stale-action@main
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Add the common-stale-action for marking issues and PRs as stale. This is consistent with all osbuild group projects.