### PR TITLE
cmd/describe: ensure that all image types can be described (HMS-7044)

### DIFF
--- a/cmd/image-builder/describeimg.go
+++ b/cmd/image-builder/describeimg.go
@@ -13,6 +13,7 @@ import (
 	"github.com/osbuild/images/pkg/distro"
 	"github.com/osbuild/images/pkg/distro/defs"
 	"github.com/osbuild/images/pkg/imagefilter"
+	"github.com/osbuild/images/pkg/ostree"
 )
 
 // Use yaml output by default because it is both nicely human and
@@ -45,7 +46,16 @@ type packagesYAML struct {
 
 func packageSetsFor(imgType distro.ImageType) (map[string]*packagesYAML, error) {
 	var bp blueprint.Blueprint
-	manifest, _, err := imgType.Manifest(&bp, distro.ImageOptions{}, nil, nil)
+
+	var imgOpts distro.ImageOptions
+	// Mock ostree options for ostree-based images to make describe work
+	if imgType.OSTreeRef() != "" {
+		imgOpts.OSTree = &ostree.ImageOptions{
+			URL: "http://example.com/repo",
+		}
+	}
+
+	manifest, _, err := imgType.Manifest(&bp, imgOpts, nil, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/image-builder/describeimg.go
+++ b/cmd/image-builder/describeimg.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"slices"
+	"strings"
 
 	"gopkg.in/yaml.v3"
 
@@ -46,6 +47,14 @@ type packagesYAML struct {
 
 func packageSetsFor(imgType distro.ImageType) (map[string]*packagesYAML, error) {
 	var bp blueprint.Blueprint
+	// XXX: '*-simplified-installer' images require the installation device to be specified as a BP customization.
+	// Workaround this for now by setting a dummy device. We should ideally have a way to get image type pkg sets
+	// without doing this.
+	if strings.HasSuffix(imgType.Name(), "-simplified-installer") {
+		bp.Customizations = &blueprint.Customizations{
+			InstallationDevice: "/dev/dummy",
+		}
+	}
 
 	var imgOpts distro.ImageOptions
 	// Mock ostree options for ostree-based images to make describe work

--- a/cmd/image-builder/describeimg_test.go
+++ b/cmd/image-builder/describeimg_test.go
@@ -2,13 +2,17 @@ package main_test
 
 import (
 	"bytes"
+	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"sigs.k8s.io/yaml"
 
 	testrepos "github.com/osbuild/images/test/data/repositories"
 
-	"github.com/osbuild/image-builder-cli/cmd/image-builder"
+	main "github.com/osbuild/image-builder-cli/cmd/image-builder"
 )
 
 func TestDescribeImage(t *testing.T) {
@@ -57,4 +61,35 @@ packages:
       - rng-tools
 `
 	assert.Equal(t, expectedOutput, buf.String())
+}
+
+func TestDescribeImageAll(t *testing.T) {
+	restore := main.MockNewRepoRegistry(testrepos.New)
+	defer restore()
+
+	allImages, err := main.GetAllImages(nil)
+	require.NoError(t, err)
+	require.NotEmpty(t, allImages)
+
+	for _, res := range allImages {
+		t.Run(fmt.Sprintf("%s/%s/%s", res.Distro.Name(), res.Arch.Name(), res.ImgType.Name()), func(t *testing.T) {
+			var buf bytes.Buffer
+			err = main.DescribeImage(&res, &buf)
+			require.NoError(t, err)
+
+			// check that the first line of the output contains the "@WARNING" message
+			lines := strings.Split(buf.String(), "\n")
+			require.NotEmpty(t, lines)
+			require.Equal(t, "@WARNING - the output format is not stable yet and may change", lines[0])
+
+			// the rest of the output should contain a valid YAML representation of the image
+			describeOutput := strings.Join(lines[1:], "\n")
+			var imgDef main.DescribeImgYAML
+			err := yaml.Unmarshal([]byte(describeOutput), &imgDef)
+			require.NoError(t, err)
+			require.Equal(t, res.Distro.Name(), imgDef.Distro)
+			require.Equal(t, res.Arch.Name(), imgDef.Arch)
+			require.Equal(t, res.ImgType.Name(), imgDef.Type)
+		})
+	}
 }

--- a/cmd/image-builder/export_test.go
+++ b/cmd/image-builder/export_test.go
@@ -13,12 +13,15 @@ import (
 
 var (
 	GetOneImage     = getOneImage
+	GetAllImages    = getAllImages
 	Run             = run
 	FindDistro      = findDistro
 	DescribeImage   = describeImage
 	ProgressFromCmd = progressFromCmd
 	BasenameFor     = basenameFor
 )
+
+type DescribeImgYAML describeImgYAML
 
 func MockOsArgs(new []string) (restore func()) {
 	saved := os.Args

--- a/cmd/image-builder/filters.go
+++ b/cmd/image-builder/filters.go
@@ -76,3 +76,22 @@ func getOneImage(distroName, imgTypeStr, archStr string, repoOpts *repoOptions) 
 		return nil, fmt.Errorf("internal error: found %v results for %q %q %q", len(filteredResults), distroName, imgTypeStr, archStr)
 	}
 }
+
+// getAllImages returns all images matching the filter expressions.
+func getAllImages(repoOpts *repoOptions, filterExprs ...string) ([]imagefilter.Result, error) {
+	if repoOpts == nil {
+		repoOpts = &repoOptions{}
+	}
+
+	imageFilter, err := newImageFilterDefault(repoOpts.DataDir, repoOpts.ExtraRepos)
+	if err != nil {
+		return nil, err
+	}
+
+	filteredResults, err := imageFilter.Filter(filterExprs...)
+	if err != nil {
+		return nil, err
+	}
+
+	return filteredResults, nil
+}

--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/stretchr/testify v1.10.0
 	golang.org/x/sys v0.30.0
 	gopkg.in/yaml.v3 v3.0.1
+	sigs.k8s.io/yaml v1.4.0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -143,6 +143,7 @@ github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMyw
 github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.3/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
@@ -237,8 +238,6 @@ github.com/opencontainers/selinux v1.11.1 h1:nHFvthhM0qY8/m+vfhJylliSshm8G1jJ2jD
 github.com/opencontainers/selinux v1.11.1/go.mod h1:E5dMC3VPuVvVHDYmi78qvhJp8+M586T4DlDRYpFkyec=
 github.com/osbuild/blueprint v1.5.0 h1:ca3C32Ltx+2P2eEZrI1fyutAInpwojl+NdQZKOrIR+Q=
 github.com/osbuild/blueprint v1.5.0/go.mod h1:0d3dlY8aSJ6jM6NHwBmJFF1VIySsp/GsDpcJQ0yrOqM=
-github.com/osbuild/images v0.149.0 h1:gAmgwbsSer16vX8tkOcXM2TFqzQ2tQUApSOwutt8Q5Q=
-github.com/osbuild/images v0.149.0/go.mod h1:ZiEO1WWKuRvPSaiXsmqn+7krAIZ+qXiiOfBQed0H7lY=
 github.com/osbuild/images v0.153.0 h1:NPPhtq/WWE5DK7psKFZ/cO4OSaRd+FYsYqPG48WBgzk=
 github.com/osbuild/images v0.153.0/go.mod h1:ZiEO1WWKuRvPSaiXsmqn+7krAIZ+qXiiOfBQed0H7lY=
 github.com/ostreedev/ostree-go v0.0.0-20210805093236-719684c64e4f h1:/UDgs8FGMqwnHagNDPGOlts35QkhAZ8by3DR7nMih7M=
@@ -504,3 +503,5 @@ gotest.tools/v3 v3.5.1 h1:EENdUnS3pdur5nybKYIh2Vfgc8IUNBjxDPSjtiJcOzU=
 gotest.tools/v3 v3.5.1/go.mod h1:isy3WKz7GK6uNw/sbHzfKBLvlvXwUyV06n6brMxxopU=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
+sigs.k8s.io/yaml v1.4.0 h1:Mk1wCc2gy/F0THH0TAp1QYyJNzRm2KCLy3o5ASXVI5E=
+sigs.k8s.io/yaml v1.4.0/go.mod h1:Ejl7/uTz7PSA4eKMyQCUTnhZYNmLIl+5c2lQPGR2BPY=


### PR DESCRIPTION
It turned out that some image types could not be previously described using the `describe` command. Specifically, two kinds of images:

- OSTree-based images, because these require specifying additional parameters to generate their manifest (which is the way we currently get the image type's package set).
- `*-simplified-installer` images, because these require setting the installation device in the BP customizations to generate their manifest.

This PR adds a unit test that verifies that all image types can be successfully described and fixes the issues.