### PR TITLE
doc/01-usage.md: avoid multiple h1 in one document

### DIFF
--- a/doc/01-usage.md
+++ b/doc/01-usage.md
@@ -218,7 +218,7 @@ $ image-builder manifest --arch aarch64 minimal-raw
 # ... output ...
 ```
 
-# Blueprints
+## Blueprints
 
 Images can be customized with [blueprints](https://osbuild.org/docs/user-guide/blueprint-reference). For example we could build the `qcow2` we built above with some customizations applied.
 


### PR DESCRIPTION
Due to https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/Heading_Elements#avoid_using_multiple_h1_elements_on_one_page metioned in #234 we'll just use a single h1 per document.