### PR TITLE
main: add support disk based bootc images via --bootc-ref  (HMS-8845)

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -1,4 +1,4 @@
-FROM registry.fedoraproject.org/fedora:41 AS builder
+FROM registry.fedoraproject.org/fedora:42 AS builder
 RUN dnf install -y git-core golang gpgme-devel libassuan-devel && mkdir -p /build/
 ARG GOPROXY=https://proxy.golang.org,direct
 RUN go env -w GOPROXY=$GOPROXY

--- a/cmd/image-builder/main.go
+++ b/cmd/image-builder/main.go
@@ -209,6 +209,12 @@ func cmdManifestWrapper(pbar progress.ProgressBar, cmd *cobra.Command, args []st
 	if bootcRef != "" && distroStr != "" {
 		return nil, fmt.Errorf("cannot use --distro with --bootc-ref")
 	}
+	// XXX: remove once https://github.com/osbuild/images/pull/1797
+	// and https://github.com/osbuild/bootc-image-builder/pull/1014
+	// are merged
+	if bootcRef != "" {
+		fmt.Fprintln(os.Stderr, "WARNING: bootc support is experimental")
+	}
 
 	// no error check here as this is (deliberately) not defined on
 	// "manifest" (if "images" learn to set the output filename in

--- a/cmd/image-builder/manifest.go
+++ b/cmd/image-builder/manifest.go
@@ -24,6 +24,7 @@ type manifestOptions struct {
 	OutputFilename string
 	BlueprintPath  string
 	Ostree         *ostree.ImageOptions
+	BootcRef       string
 	Subscription   *subscription.ImageOptions
 	RpmDownloader  osbuild.RpmDownloader
 	WithSBOM       bool


### PR DESCRIPTION
This PR adds support for building bootc based disk images via the new `--bootc-ref` switch. It requires support in the images library.

/jira-epic HMS-8839

JIRA: [HMS-8845](https://issues.redhat.com/browse/HMS-8845)