### PR TITLE
packit: enable RHEL 10 builds (HMS-8829)

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -60,6 +60,8 @@ jobs:
       - fedora-all
       - rhel-9-aarch64
       - rhel-9-x86_64
+      - rhel-10-aarch64
+      - rhel-10-x86_64
   - job: copr_build
     trigger: commit
     branch: main


### PR DESCRIPTION
COPR now supports them, so let's add them! 🚀

/jira-epic HMS-8815

JIRA: [HMS-8829](https://issues.redhat.com/browse/HMS-8829)