### PR TITLE
chore: set specfile version at build

### DIFF
--- a/image-builder.spec
+++ b/image-builder.spec
@@ -85,7 +85,7 @@ export GOFLAGS+=" -mod=vendor"
 GOTAGS="exclude_graphdriver_btrfs"
 %endif
 
-export LDFLAGS="${LDFLAGS} -X 'main.BuildVersion=%{version}'"
+export LDFLAGS="${LDFLAGS} -X 'main.version=%{version}'"
 %gobuild ${GOTAGS:+-tags=$GOTAGS} -o %{gobuilddir}/bin/image-builder %{goipath}/cmd/image-builder
 
 %install


### PR DESCRIPTION
In [1] I changed the name of the variable used to deduce the version built. I forgot to update this in the specfile. Let's correct that.

[1]: https://github.com/osbuild/image-builder-cli/pull/230