### PR TITLE
ci/packit: remove EPEL release automation

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -29,20 +29,14 @@ jobs:
     trigger: commit
     dist_git_branches:
       - fedora-branched  # rawhide updates are created automatically
-      - epel-10
-      - epel9-next
   - job: koji_build
     trigger: commit
     dist_git_branches:
       - fedora-all
-      - epel-10
-      - epel-9-next
   - job: propose_downstream
     trigger: release
     dist_git_branches:
       - fedora-all
-      - epel-10
-      - epel9-next
   - job: copr_build
     trigger: pull_request
     targets: &build_targets


### PR DESCRIPTION
With `image-builder` having been released into CentOS we should no longer ship updates for EPEL.