### PR TITLE
main: add (hidden) pkgsearch command

### DIFF
--- a/cmd/image-builder/pkgsearch.go
+++ b/cmd/image-builder/pkgsearch.go
@@ -1,0 +1,74 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+
+	"github.com/spf13/cobra"
+
+	"github.com/osbuild/image-builder-cli/pkg/progress"
+	"github.com/osbuild/images/pkg/dnfjson"
+	"github.com/osbuild/images/pkg/rpmmd"
+)
+
+type pkgSearchFormatter interface {
+	Output(io.Writer, rpmmd.PackageList) error
+}
+
+func newPkgSearchFormatter(format string) (pkgSearchFormatter, error) {
+	switch format {
+	case "json":
+		return &jsonPkgSearchFormatter{}, nil
+	default:
+		return nil, fmt.Errorf("unsupported results formatter %q (try --format=json)", format)
+	}
+}
+
+type pkgSearchResultJSON struct {
+	Packages rpmmd.PackageList
+}
+type jsonPkgSearchFormatter struct{}
+
+func (*jsonPkgSearchFormatter) Output(w io.Writer, pkgs rpmmd.PackageList) error {
+	enc := json.NewEncoder(w)
+	return enc.Encode(struct {
+		Packages rpmmd.PackageList
+	}{
+		Packages: pkgs,
+	})
+}
+
+func cmdPkgSearch(cmd *cobra.Command, args []string) error {
+	format, err := cmd.Flags().GetString("format")
+	if err != nil {
+		return err
+	}
+
+	pbar, err := progress.New("")
+	if err != nil {
+		return err
+	}
+	img, err := cmdGetOneImage(pbar, cmd, args)
+	if err != nil {
+		return err
+	}
+	// XXX: set a sensible cachedir here
+	cacheDir := ""
+	d := img.Distro
+
+	solver := dnfjson.NewSolver(d.ModulePlatformID(), d.Releasever(), img.Arch.Name(), d.Name(), cacheDir)
+	results, err := solver.SearchMetadata(img.Repos, args[1:])
+	if err != nil {
+		return err
+	}
+	fmter, err := newPkgSearchFormatter(format)
+	if err != nil {
+		return err
+	}
+	if err := fmter.Output(osStdout, results); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/go.mod
+++ b/go.mod
@@ -121,3 +121,5 @@ require (
 	gopkg.in/ini.v1 v1.67.0 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 )
+
+replace github.com/osbuild/images => github.com/mvo5/images v0.0.0-20250804145649-0a6396764aa4

--- a/go.sum
+++ b/go.sum
@@ -199,6 +199,8 @@ github.com/morikuni/aec v1.0.0 h1:nP9CBfwrvYnBRgY6qfDQkygYDmYwOilePFkwzv4dU8A=
 github.com/morikuni/aec v1.0.0/go.mod h1:BbKIizmSmc5MMPqRYbxO4ZU0S0+P200+tUnFx7PXmsc=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
+github.com/mvo5/images v0.0.0-20250804145649-0a6396764aa4 h1:dTu1L7BhuRYAxURUEabPMgvdR5SRI74zkRAPdh/A7rM=
+github.com/mvo5/images v0.0.0-20250804145649-0a6396764aa4/go.mod h1:WwKRXlJ7ksVf5jLNpKk2XBRBoX/+/7jrojS2hCm2aDw=
 github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8Oi/yOhh5U=
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
 github.com/opencontainers/image-spec v1.1.1 h1:y0fUlFfIZhPF1W537XOLg0/fcx6zcHCJwooC2xJA040=
@@ -209,8 +211,6 @@ github.com/opencontainers/selinux v1.12.0 h1:6n5JV4Cf+4y0KNXW48TLj5DwfXpvWlxXplU
 github.com/opencontainers/selinux v1.12.0/go.mod h1:BTPX+bjVbWGXw7ZZWUbdENt8w0htPSrlgOOysQaU62U=
 github.com/osbuild/blueprint v1.10.0 h1:6TG+mSV5kUA3Vq+0fc10MchDilBcDd8SEA8KbDFUn2w=
 github.com/osbuild/blueprint v1.10.0/go.mod h1:uknOfX/bAoi+dbeNJj+uAir1T++/LVEtoY8HO3U7MiQ=
-github.com/osbuild/images v0.168.0 h1:qPmm9d28Py8/TrfzzyCjHAOdcXG4//NbF1EO3I8NanA=
-github.com/osbuild/images v0.168.0/go.mod h1:WwKRXlJ7ksVf5jLNpKk2XBRBoX/+/7jrojS2hCm2aDw=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=


### PR DESCRIPTION
[draft as this needs tests and also a small change in images]

This commit adds a new hidden pkgsearch command that can be
used to how information about specific packages within the
given distro/arch/imagetype context.

This needs:
https://github.com/osbuild/images/compare/main...mvo5:imagefilter-res-repos?expand=1
