### PR TITLE
Install openssl in cli container

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -18,7 +18,7 @@ RUN mkdir -p /etc/containers/networks
 # Fast-track osbuild so we don't depend on the "slow" Fedora release process to implement new features in bib
 RUN dnf install -y dnf-plugins-core \
     && dnf copr enable -y @osbuild/osbuild \
-    && dnf install -y libxcrypt-compat wget osbuild osbuild-ostree osbuild-depsolve-dnf osbuild-lvm2 \
+    && dnf install -y libxcrypt-compat wget osbuild osbuild-ostree osbuild-depsolve-dnf osbuild-lvm2 openssl \
     && dnf clean all
 
 COPY --from=builder /build/image-builder /usr/bin/


### PR DESCRIPTION
Using the container and building with a config.toml with a password will fail with:

```
Building manifest for bootc-based-qcow2
panic: user stage failed cannot generate password: exec: "openssl": executable file not found in $PATH, output:
	

goroutine 1 [running]:
github.com/osbuild/images/pkg/manifest.(*RawBootcImage).serialize(0xc0002466c0)
	/root/go/pkg/mod/github.com/osbuild/images@v0.182.0/pkg/manifest/raw_bootc.go:206 +0x16dc
github.com/osbuild/images/pkg/manifest.Manifest.Serialize({{0xc000907400, 0x8, 0x8}, 0x5, {0x0, 0x0}}, 0xc00042ab40, 0xc00042aba0, 0xc0007d0780, 0xc000635448)
	/root/go/pkg/mod/github.com/osbuild/images@v0.182.0/pkg/manifest/manifest.go:191 +0x3e5
```