### PR TITLE
cmd/upload: add fedora ami to aws upload (HMS-9388)

### DIFF
--- a/cmd/image-builder/upload.go
+++ b/cmd/image-builder/upload.go
@@ -67,7 +67,7 @@ func uploaderCheckWithProgress(pbar progress.ProgressBar, uploader cloud.Uploade
 
 func uploaderFor(cmd *cobra.Command, typeOrCloud string, targetArch string, bootMode *platform.BootMode) (cloud.Uploader, error) {
 	switch typeOrCloud {
-	case "ami", "aws":
+	case "ami", "server-ami", "aws":
 		return uploaderForCmdAWS(cmd, targetArch, bootMode)
 	default:
 		return nil, fmt.Errorf("%w: %q", ErrUploadTypeUnsupported, typeOrCloud)


### PR DESCRIPTION
Fedora aws images were getting ignored since we renamed the base image type to `server-ami`, this commit adds that type back so that we can build Fedora based aws images.

Fixes https://github.com/osbuild/image-builder-cli/issues/306