### PR TITLE
deps: update to images 0.193.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/gobwas/glob v0.2.3
 	github.com/mattn/go-isatty v0.0.20
 	github.com/osbuild/blueprint v1.13.0
-	github.com/osbuild/images v0.192.0
+	github.com/osbuild/images v0.193.0
 	github.com/spf13/cobra v1.9.1
 	github.com/stretchr/testify v1.11.1
 	golang.org/x/sys v0.35.0

--- a/go.sum
+++ b/go.sum
@@ -247,6 +247,8 @@ github.com/osbuild/images v0.191.0 h1:nhTIAf0JJTEf1gIUsU1II0BVIYBj537BvDpBBXCLYi
 github.com/osbuild/images v0.191.0/go.mod h1:KPiYBF0VrOXz5NAw6Lv4X170uN8wnOHpWuBzKT4jPrU=
 github.com/osbuild/images v0.192.0 h1:H2HMlveugSeNAWecwVqBbH8wooNfk4rNxlCQHGq9Ue8=
 github.com/osbuild/images v0.192.0/go.mod h1:KPiYBF0VrOXz5NAw6Lv4X170uN8wnOHpWuBzKT4jPrU=
+github.com/osbuild/images v0.193.0 h1:My/Ujx/Eq25jwob3nl4Qx0M7cUZdmP8kuQqLqeoHDo0=
+github.com/osbuild/images v0.193.0/go.mod h1:KPiYBF0VrOXz5NAw6Lv4X170uN8wnOHpWuBzKT4jPrU=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=


### PR DESCRIPTION
This includes the enablement of the `ec2` image type for CentOS Stream.