### PR TITLE
gitignore: add common image formats

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,10 @@ release_artifacts
 dictionary.dic
 __pycache__
 /bin
+*.raw.xz
+*.qcow2
+*.img.xz
+*.iso
+*.tar.gz
+*.tar.xz
+*.tar.bz2


### PR DESCRIPTION
I managed to commit a test image, this should prevent that in future.

---

Not sure how you feel about this. Anyways, here it is.

This was split out of: https://github.com/osbuild/image-builder-cli/pull/303