### PR TITLE
progress: detect real terminal width for messages

### DIFF
--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -82,7 +82,7 @@ jobs:
       - name: Install integration test env
         run: |
           sudo apt update
-          sudo apt install -y python3-pytest golang
+          sudo apt install -y python3-pytest golang asciinema
       - name: Run integration tests via pytest
         run: |
           # use "-s" for now for easier debugging

--- a/.gitignore
+++ b/.gitignore
@@ -12,4 +12,5 @@ __pycache__
 *.tar.gz
 *.tar.xz
 *.tar.bz2
+recording-*.cast.json
 /image-builder

--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/spf13/cobra v1.9.1
 	github.com/stretchr/testify v1.11.1
 	golang.org/x/sys v0.35.0
+	golang.org/x/term v0.34.0
 	gopkg.in/yaml.v3 v3.0.1
 	sigs.k8s.io/yaml v1.5.0
 )
@@ -132,7 +133,6 @@ require (
 	golang.org/x/exp v0.0.0-20250103183323-7d7fa50e5329 // indirect
 	golang.org/x/net v0.43.0 // indirect
 	golang.org/x/sync v0.16.0 // indirect
-	golang.org/x/term v0.34.0 // indirect
 	golang.org/x/text v0.28.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20250818200422-3122310a409c // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20250818200422-3122310a409c // indirect

--- a/pkg/progress/export_test.go
+++ b/pkg/progress/export_test.go
@@ -45,3 +45,11 @@ func MockOsbuildCmd(s string) (restore func()) {
 		osbuildCmd = saved
 	}
 }
+
+func MockGetTerminalSize(fn func() (int, int)) (restore func()) {
+	saved := getTerminalSize
+	getTerminalSize = fn
+	return func() {
+		getTerminalSize = saved
+	}
+}

--- a/pkg/progress/pty.go
+++ b/pkg/progress/pty.go
@@ -1,0 +1,55 @@
+package progress
+
+import (
+	"os"
+	"os/signal"
+	"sync"
+	"syscall"
+
+	"github.com/mattn/go-isatty"
+	"golang.org/x/term"
+)
+
+var isattyIsTerminal = isatty.IsTerminal
+
+var (
+	terminalWidth  int
+	terminalHeight int
+
+	sizeMutex sync.RWMutex
+)
+
+func init() {
+	sigChan := make(chan os.Signal, 1)
+	signal.Notify(sigChan, syscall.SIGWINCH)
+
+	go func() {
+		for {
+			<-sigChan
+			updateTerminalSize(os.Stdout.Fd())
+		}
+	}()
+}
+
+// updateTerminalSize updates the current terminal size.
+func updateTerminalSize(fd uintptr) {
+	width, height, err := term.GetSize(int(fd))
+	if err != nil {
+		width = 0
+		height = 0
+	}
+
+	sizeMutex.Lock()
+	defer sizeMutex.Unlock()
+
+	terminalWidth = width
+	terminalHeight = height
+}
+
+// getTerminalSize safely reads the stored terminal size.
+var getTerminalSize = func() (int, int) {
+	sizeMutex.RLock()
+	defer sizeMutex.RUnlock()
+
+	return terminalWidth, terminalHeight
+}

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -35,3 +35,13 @@ func OutputErr(err error) error {
 	}
 	return err
 }
+
+// ShortenString shortens a string to the specified length. If the string is
+// longer than length, it appends a unicode ellipsis character. If length is 0,
+// it returns the unmodified string.
+func ShortenString(msg string, length int) string {
+	if length > 0 && len(msg) > length {
+		return msg[:length-1] + "…"
+	}
+	return msg
+}

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -19,3 +19,25 @@ func TestOutputErrExecError(t *testing.T) {
 	_, err := exec.Command("bash", "-c", ">&2 echo some-stderr; exit 1").Output()
 	assert.Equal(t, "exit status 1, stderr:\nsome-stderr\n", util.OutputErr(err).Error())
 }
+
+func TestShortenString(t *testing.T) {
+	for _, tc := range []struct {
+		input    string
+		length   int
+		expected string
+	}{
+		{"", 0, ""},
+		{"", 1, ""},
+		{"short", 10, "short"},
+		{"exactlyten", 10, "exactlyten"},
+		{"12345678901234", 10, "123456789…"}, // returns 10 not 11 chars
+		{"new\nline", 10, "new\nline"},
+		{"new\nline that is way too long", 10, "new\nline …"},
+		{"xx", 1, "…"},
+		{"xx", 0, "xx"},
+	} {
+		t.Run(fmt.Sprintf("%q/%d", tc.input, tc.length), func(t *testing.T) {
+			assert.Equal(t, tc.expected, util.ShortenString(tc.input, tc.length))
+		})
+	}
+}


### PR DESCRIPTION
There is a common pattern in the progress bar code to shorten strings to fit into terminal width. This commit introduces a new utility function for that. It also introduces a fallback terminal width of 80 columns in case the terminal size cannot be determined.

Added a test for the function and made sure it never returns string longer than the specified length. That was not the case for the previous implementation.

Additionally, the progress bar implementation was updated to dynamically detect the terminal width and adjust message lengths accordingly. This ensures that progress messages are fully visible without being truncated, enhancing user experience during long-running operations.

There is few characters left for the spinner and padding, so we subtract 10 from the terminal width when setting message lengths.

A new dependency was introduced, but it was already an indirect one.

Also, turns out the container test does not actually run with any terminal size variables, so I added a fixed terminal size to the podman run command.

---

Split out of: https://github.com/osbuild/image-builder-cli/pull/303