### PR TITLE
main: add osbuild version to version command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ __pycache__
 *.tar.gz
 *.tar.xz
 *.tar.bz2
+/image-builder

--- a/cmd/image-builder/main.go
+++ b/cmd/image-builder/main.go
@@ -479,13 +479,22 @@ image-type and blueprint.
 Image-builder builds operating system images for a range of predefined
 operating systems like Fedora, CentOS and RHEL with easy customizations support.`,
 		SilenceErrors: true,
-		Version:       prettyVersion(),
 		CompletionOptions: cobra.CompletionOptions{
 			HiddenDefaultCmd: true,
 		},
+		Run: func(cmd *cobra.Command, args []string) {
+			// This is not the ideal way to implement this, but cobra does not
+			// support lazy version strings and we need to call "osbuild" subprocess
+			// to get its version.
+			if versionFlag, err := cmd.Flags().GetBool("version"); err == nil && versionFlag {
+				fmt.Print(prettyVersion())
+			} else {
+				cmd.Help()
+			}
+		},
 	}
-	rootCmd.SetVersionTemplate(prettyVersion())
 
+	rootCmd.Flags().Bool("version", false, "Print version information and exit")
 	rootCmd.PersistentFlags().String("data-dir", "", `Override the default data directory for e.g. custom repositories/*.json data`)
 	rootCmd.PersistentFlags().StringArray("extra-repo", nil, `Add an extra repository during build (will *not* be gpg checked and not be part of the final image)`)
 	rootCmd.PersistentFlags().StringArray("force-repo", nil, `Override the base repositories during build (these will not be part of the final image)`)

--- a/cmd/image-builder/version.go
+++ b/cmd/image-builder/version.go
@@ -1,9 +1,12 @@
 package main
 
 import (
+	"fmt"
+	"os"
 	"runtime/debug"
 	"strings"
 
+	"github.com/osbuild/images/pkg/osbuild"
 	"gopkg.in/yaml.v3"
 )
 
@@ -16,7 +19,8 @@ type versionDescription struct {
 		Version      string `yaml:"version"`
 		Commit       string `yaml:"commit"`
 		Dependencies struct {
-			Images string `yaml:"images"`
+			Images  string `yaml:"images"`
+			OSBuild string `yaml:"osbuild"`
 		} `yaml:"dependencies"`
 	} `yaml:"image-builder"`
 }
@@ -28,8 +32,9 @@ func readVersionInfo() *versionDescription {
 	// they will always be set to unknown. Note that `version` is set globally so it can
 	// be defined by whatever is building this project.
 	vd.ImageBuilder.Commit = "unknown"
-	vd.ImageBuilder.Version = "unknown"
+	vd.ImageBuilder.Version = version
 	vd.ImageBuilder.Dependencies.Images = "unknown"
+	vd.ImageBuilder.Dependencies.OSBuild = "unknown"
 
 	if bi, ok := debug.ReadBuildInfo(); ok {
 		for _, bs := range bi.Settings {
@@ -45,6 +50,12 @@ func readVersionInfo() *versionDescription {
 			}
 		}
 	}
+
+	osbuildVersion, err := osbuild.OSBuildVersion()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to get osbuild version: %v\n", err)
+	}
+	vd.ImageBuilder.Dependencies.OSBuild = osbuildVersion
 
 	return vd
 }

--- a/cmd/image-builder/version.go
+++ b/cmd/image-builder/version.go
@@ -22,33 +22,29 @@ type versionDescription struct {
 }
 
 func readVersionInfo() *versionDescription {
+	vd := &versionDescription{}
+
 	// We'll be getting these values from the build info if they're available, otherwise
 	// they will always be set to unknown. Note that `version` is set globally so it can
 	// be defined by whatever is building this project.
-	commit := "unknown"
-	images := "unknown"
+	vd.ImageBuilder.Commit = "unknown"
+	vd.ImageBuilder.Version = "unknown"
+	vd.ImageBuilder.Dependencies.Images = "unknown"
 
 	if bi, ok := debug.ReadBuildInfo(); ok {
 		for _, bs := range bi.Settings {
 			switch bs.Key {
 			case "vcs.revision":
-				commit = bs.Value
+				vd.ImageBuilder.Commit = bs.Value
 			}
 		}
 
 		for _, dep := range bi.Deps {
 			if dep.Path == "github.com/osbuild/images" {
-				images = dep.Version
+				vd.ImageBuilder.Dependencies.Images = dep.Version
 			}
 		}
 	}
-
-	vd := &versionDescription{}
-
-	vd.ImageBuilder.Version = version
-	vd.ImageBuilder.Commit = commit
-
-	vd.ImageBuilder.Dependencies.Images = images
 
 	return vd
 }

--- a/cmd/image-builder/version.go
+++ b/cmd/image-builder/version.go
@@ -7,7 +7,7 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-// Usually set by whatever is building the binary with a `-x main.version=22`, for example
+// Usually set by whatever is building the binary with a `-X main.version=22`, for example
 // in `make build`.
 var version = "unknown"
 

--- a/cmd/image-builder/version.go
+++ b/cmd/image-builder/version.go
@@ -21,7 +21,7 @@ type versionDescription struct {
 	} `yaml:"image-builder"`
 }
 
-func readVersionFromBinary() *versionDescription {
+func readVersionInfo() *versionDescription {
 	// We'll be getting these values from the build info if they're available, otherwise
 	// they will always be set to unknown. Note that `version` is set globally so it can
 	// be defined by whatever is building this project.
@@ -59,7 +59,7 @@ func prettyVersion() string {
 	enc := yaml.NewEncoder(&b)
 	enc.SetIndent(2)
 
-	enc.Encode(readVersionFromBinary())
+	enc.Encode(readVersionInfo())
 
 	return b.String()
 }

--- a/test/test_container.py
+++ b/test/test_container.py
@@ -163,6 +163,7 @@ def test_container_version_smoke(build_container):
     assert ver_yaml["image-builder"]["version"] != ""
     assert ver_yaml["image-builder"]["commit"] != ""
     assert ver_yaml["image-builder"]["dependencies"]["images"] != ""
+    assert ver_yaml["image-builder"]["dependencies"]["osbuild"] != ""
 
 
 def test_container_builds_bootc(tmp_path, build_container):


### PR DESCRIPTION
```
Because I have modified my PATH to include a custom osbuild binary, it
is useful to see which osbuild version is being used by image-builder.
After this change, the output looks like this:

$ go run ./cmd/image-builder --version
image-builder:
  version: unknown
  commit: unknown
  dependencies:
    images: v0.197.0
    osbuild: osbuild 162
```

---

A very tiny refactoring to improve readability of the function.