### PR TITLE
blueprintload: improve error message in Load

### DIFF
--- a/internal/blueprintload/blueprintload.go
+++ b/internal/blueprintload/blueprintload.go
@@ -54,7 +54,7 @@ func Load(path string) (*blueprint.Blueprint, error) {
 	default:
 		fp, err = os.Open(path)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("cannot open blueprint file %q: %w", path, err)
 		}
 		defer fp.Close()
 	}


### PR DESCRIPTION
When working with ibcli in podman with a blueprint, I got this error message:

Error: statfs /tmp/bp.toml: no such file or directory

I actually have no idea if podman failed because it couldn't find the file on the host, or if image-builder failed because it couldn't find it in the container.

So let's add a bit more context to the error message.