### PR TITLE
ci: consistent triggers for spec check

### DIFF
--- a/.github/workflows/check-spec.yaml
+++ b/.github/workflows/check-spec.yaml
@@ -2,11 +2,11 @@ name: RPM
 
 on:  # yamllint disable-line rule:truthy
   pull_request:
-    branches:
-      - "*"
+    branches: ["main"]
   push:
-    branches:
-      - main
+    branches: ["main"]
+  merge_group:
+    types: ["checks_requested"]
 
 jobs:
   check-spec-images-deps:


### PR DESCRIPTION
The spec check isn't set to run in the merge queue which blocks other PRs from merging. Let's set it to allow-to-run. Also make the branches targeted by PRs that it runs on consistent.