### PR TITLE
deps: switch yaml libraries

### DIFF
--- a/cmd/image-builder/describeimg.go
+++ b/cmd/image-builder/describeimg.go
@@ -7,7 +7,7 @@ import (
 	"slices"
 	"strings"
 
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 
 	"github.com/osbuild/blueprint/pkg/blueprint"
 	"github.com/osbuild/images/pkg/disk"

--- a/cmd/image-builder/version.go
+++ b/cmd/image-builder/version.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 
 	"github.com/osbuild/images/pkg/osbuild"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 // Usually set by whatever is building the binary with a `-X main.version=22`, for example

--- a/go.mod
+++ b/go.mod
@@ -15,9 +15,9 @@ require (
 	github.com/osbuild/images v0.206.0
 	github.com/spf13/cobra v1.9.1
 	github.com/stretchr/testify v1.11.1
+	go.yaml.in/yaml/v3 v3.0.3
 	golang.org/x/sys v0.35.0
 	golang.org/x/term v0.34.0
-	gopkg.in/yaml.v3 v3.0.1
 	sigs.k8s.io/yaml v1.5.0
 )
 
@@ -139,5 +139,6 @@ require (
 	google.golang.org/grpc v1.74.2 // indirect
 	google.golang.org/protobuf v1.36.7 // indirect
 	gopkg.in/ini.v1 v1.67.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 	libvirt.org/go/libvirt v1.11006.0 // indirect
 )


### PR DESCRIPTION
During a recent chat it was brought up that `go.pkg.in/yaml.v3` is unmaintained. The YAML organization forked the unmaintained package and is now updating it. The `v3` we use here only receives security fixes while `v4` will eventually support new features and more of YAML.

Let's do the easy an uncontroversial swap first as this is a maintained drop-in replacement.

---

Note, this is not `goccy/go-yaml` which has additional features it is `yaml/go-yaml`.