### PR TITLE
main: add `--rpmmd-cache` options [HMS-9646]

### DIFF
--- a/cmd/image-builder/main.go
+++ b/cmd/image-builder/main.go
@@ -145,6 +145,10 @@ func cmdManifestWrapper(pbar progress.ProgressBar, cmd *cobra.Command, args []st
 	if err != nil {
 		return nil, err
 	}
+	rpmmdCacheDir, err := cmd.Flags().GetString("rpmmd-cache")
+	if err != nil {
+		return nil, err
+	}
 	extraRepos, err := cmd.Flags().GetStringArray("extra-repo")
 	if err != nil {
 		return nil, err
@@ -299,6 +303,7 @@ func cmdManifestWrapper(pbar progress.ProgressBar, cmd *cobra.Command, args []st
 		IgnoreWarnings:           ignoreWarnings,
 		CustomSeed:               customSeed,
 		Subscription:             subscription,
+		RpmmdCacheDir:            rpmmdCacheDir,
 
 		ForceRepos: forceRepos,
 	}
@@ -542,6 +547,7 @@ operating systems like Fedora, CentOS and RHEL with easy customizations support.
 	manifestCmd.Flags().Bool("with-sbom", false, `export SPDX SBOM document`)
 	manifestCmd.Flags().Bool("ignore-warnings", false, `ignore warnings during manifest generation`)
 	manifestCmd.Flags().String("registrations", "", `filename of a registrations file with e.g. subscription details`)
+	manifestCmd.Flags().String("rpmmd-cache", "", `osbuild directory to cache rpm metadata`)
 	rootCmd.AddCommand(manifestCmd)
 
 	uploadCmd := &cobra.Command{
@@ -574,7 +580,6 @@ operating systems like Fedora, CentOS and RHEL with easy customizations support.
 	buildCmd.Flags().AddFlagSet(manifestCmd.Flags())
 	buildCmd.Flags().Bool("with-manifest", false, `export osbuild manifest`)
 	buildCmd.Flags().Bool("with-buildlog", false, `export osbuild buildlog`)
-	// XXX: add --rpmmd cache too and put under /var/cache/image-builder/dnf
 	buildCmd.Flags().String("cache", "/var/cache/image-builder/store", `osbuild directory to cache intermediate build artifacts"`)
 	// XXX: add "--verbose" here, similar to how bib is doing this
 	// (see https://github.com/osbuild/bootc-image-builder/pull/790/commits/5cec7ffd8a526e2ca1e8ada0ea18f927695dfe43)

--- a/cmd/image-builder/manifest.go
+++ b/cmd/image-builder/manifest.go
@@ -31,6 +31,7 @@ type manifestOptions struct {
 	WithSBOM                 bool
 	IgnoreWarnings           bool
 	CustomSeed               *int64
+	RpmmdCacheDir            string
 
 	ForceRepos            []string
 	UseBootstrapContainer bool
@@ -63,13 +64,13 @@ func generateManifest(dataDir string, extraRepos []string, img *imagefilter.Resu
 	if err != nil {
 		return err
 	}
-	// XXX: add --rpmmd/cachedir option like bib
 	manifestGenOpts := &manifestgen.Options{
 		DepsolveWarningsOutput: depsolveWarningsOutput,
 		RpmDownloader:          opts.RpmDownloader,
 		UseBootstrapContainer:  opts.UseBootstrapContainer,
 		CustomSeed:             opts.CustomSeed,
 		Depsolver:              manifestgenDepsolver,
+		Cachedir:               opts.RpmmdCacheDir,
 	}
 	if opts.WithSBOM {
 		outputDir := basenameFor(img, opts.OutputDir)

--- a/test/test_manifest.py
+++ b/test/test_manifest.py
@@ -147,3 +147,17 @@ def test_container_manifest_bootc_iso_smoke(build_container):
     assert re.match(
         f'bootc switch .* registry {bootc_payload_ref}',
         kickstart_stage["options"]["%post"][0]["commands"][0])
+
+
+def test_manifest_honors_rpmmd_cache(tmp_path, build_container):
+    rpmmd_cache = tmp_path / "rpmmd"
+    rpmmd_cache.mkdir()
+    subprocess.check_call(podman_run + [
+        "-v", f"{rpmmd_cache}:/rpmmd_cache",
+        build_container,
+        "manifest",
+        "--distro", "centos-9",
+        "minimal-raw",
+        "--rpmmd-cache", "/rpmmd_cache",
+    ], text=True)
+    assert len(list(rpmmd_cache.rglob("repomd.xml"))) > 0


### PR DESCRIPTION
This commit adds a new option `--rpmmd-cache` that is similar to the option in bootc-image-builder. It is also useful for https://github.com/osbuild/osbuild-composer/pull/4904