### PR TITLE
Fix release action

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -13,5 +13,5 @@ jobs:
         uses: osbuild/release-action@main
         with:
           token: "${{ secrets.SCHUTZBOT_GITHUB_ACCESS_TOKEN }}"
-          slack_webhook_url: "${{ secrets.SLACK_WEBHOOK_URL }}"
+          slack_bot_token: "${{ secrets.SLACK_BOT_TOKEN }}"
           build_release_artifacts: 'true'


### PR DESCRIPTION
We have updated our Slack integration to use a Slack bot token instead of a webhook to be able to post threaded responses or react to messages.
For reference see: https://github.com/osbuild/release-action/pull/35

Also, all the changes from the `staging` branch were ported over to `main`, so
this should act as a drop-in replacement.
For reference see: https://github.com/osbuild/release-action/pull/36