### PR TITLE
ci: split gobump into two PRs

### DIFF
--- a/.github/workflows/gobump.yaml
+++ b/.github/workflows/gobump.yaml
@@ -4,18 +4,31 @@ name: "Updates Go dependencies via gobump"
 on:  # yamllint disable-line rule:truthy
   workflow_dispatch:
   schedule:
-    # Every Sunday at 16:00
-    - cron: "0 16 * * 0"
+    # Every Monday at 6:00 PM (one hour after images release)
+    - cron: "0 6 * * 1"
 
 jobs:
-  bump-deps-ubuntu:
+  bump-deps-without-images:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
-      - name: Run gobump-deps action
+      - name: Run gobump-deps action - images
         uses: lzap/gobump@main
         with:
           go_version: "1.23.9"
           token: ${{ secrets.SCHUTZBOT_GITHUB_ACCESS_TOKEN }}
+          include: "github.com/osbuild/images"
+          commit_message: "deps: bump osbuild/images dependency"
+
+      - name: Cleaup repository
+        run: "git reset --hard HEAD"
+
+      - name: Run gobump-deps action - all other
+        uses: lzap/gobump@main
+        with:
+          go_version: "1.23.9"
+          token: ${{ secrets.SCHUTZBOT_GITHUB_ACCESS_TOKEN }}
+          exclude: "github.com/osbuild/images"
+          commit_message: "deps: update dependencies (w/o osbuild/images)"


### PR DESCRIPTION
This splits gobump into two PRs:

* One without `osbuild/images` to prevent issues when there is a API break
* One with just `osbuild/images`, we can close this one if needed.

This is straight copy-paste from composer, no changes.

I also noticed that we need to run this on Monday rather than Sunday, this must happen after images is released to ensure fresh version.