### PR TITLE
github: disable gomod updates with dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,16 +11,3 @@ updates:
       time: "04:00"
     open-pull-requests-limit: 5
     rebase-strategy: "disabled"
-
-  # Maintain dependencies for Go
-  - package-ecosystem: "gomod"
-    directory: "/"
-    schedule:
-      interval: "daily"
-      time: "04:00"
-    groups:
-      go-deps:
-        patterns:
-          - "*"  # group all dependency updates into one PR
-    open-pull-requests-limit: 1
-    rebase-strategy: "auto"


### PR DESCRIPTION
gobump was added in b6c9cc1ef4c371faea016c35fc25d70dd526bb6d.