### PR TITLE
main: add `{supported,required}` bp options to describe-image

### DIFF
--- a/cmd/image-builder/describeimg.go
+++ b/cmd/image-builder/describeimg.go
@@ -39,11 +39,17 @@ type describeImgYAML struct {
 	Packages         map[string]*packagesYAML `yaml:"packages"`
 
 	PartitionTable *disk.PartitionTable `yaml:"partition_table,omitempty"`
+
+	Blueprint blueprintYAML `yaml:"blueprint"`
 }
 
 type packagesYAML struct {
 	Include []string `yaml:"include"`
 	Exclude []string `yaml:"exclude"`
+}
+type blueprintYAML struct {
+	SupportedOptions []string `yaml:"supported_options,omitempty"`
+	RequiredOptions  []string `yaml:"required_options,omitempty"`
 }
 
 func dummyManifestFor(imgType distro.ImageType) (*manifest.Manifest, error) {
@@ -146,6 +152,10 @@ func describeImage(img *imagefilter.Result, out io.Writer) error {
 		PayloadPipelines: m.PayloadPipelines(),
 		Packages:         pkgSets,
 		PartitionTable:   partTable,
+		Blueprint: blueprintYAML{
+			SupportedOptions: img.ImgType.SupportedBlueprintOptions(),
+			RequiredOptions:  img.ImgType.RequiredBlueprintOptions(),
+		},
 	}
 	// deliberately break the yaml until the feature is stable
 	fmt.Fprint(out, "@WARNING - the output format is not stable yet and may change\n")

--- a/cmd/image-builder/describeimg_test.go
+++ b/cmd/image-builder/describeimg_test.go
@@ -59,8 +59,72 @@ packages:
       - selinux-policy-targeted
     exclude:
       - rng-tools
+blueprint:
+  supported_options:
+    - distro
+    - packages
+    - modules
+    - groups
+    - containers
+    - enabled_modules
+    - minimal
+    - customizations.dnf
+    - customizations.cacerts
+    - customizations.directories
+    - customizations.files
+    - customizations.firewall
+    - customizations.user
+    - customizations.sshkey
+    - customizations.group
+    - customizations.hostname
+    - customizations.kernel.name
+    - customizations.locale
+    - customizations.repositories
+    - customizations.rpm
+    - customizations.services
+    - customizations.timezone
+    - name
+    - version
+    - description
 `
 	assert.Equal(t, expectedOutput, buf.String())
+}
+
+func TestDescribeImageRequiredBlueprintOptions(t *testing.T) {
+	restore := main.MockNewRepoRegistry(testrepos.New)
+	defer restore()
+
+	res, err := main.GetOneImage("centos-9", "edge-simplified-installer", "x86_64", nil)
+	assert.NoError(t, err)
+
+	var buf bytes.Buffer
+	err = main.DescribeImage(res, &buf)
+	assert.NoError(t, err)
+
+	expectedSubstr := `
+blueprint:
+  supported_options:
+    - distro
+    - customizations.dnf
+    - customizations.installation_device
+    - customizations.filesystem
+    - customizations.disk
+    - customizations.fdo
+    - customizations.ignition
+    - customizations.kernel
+    - customizations.user
+    - customizations.sshkey
+    - customizations.group
+    - customizations.fips
+    - customizations.files
+    - customizations.directories
+    - name
+    - version
+    - description
+  required_options:
+    - customizations.installation_device
+`
+	assert.Contains(t, buf.String(), expectedSubstr)
 }
 
 func TestDescribeImageAll(t *testing.T) {


### PR DESCRIPTION
We have the `{supported,required}_blueprint_options` in our YAML for a while now, so high time to expose it via describe-image as its really useful.

Thanks to Tom for suggesting this!