### PR TITLE
cmd: modify success message to include image path

### DIFF
--- a/cmd/image-builder/main.go
+++ b/cmd/image-builder/main.go
@@ -9,7 +9,6 @@ import (
 	"log"
 	"os"
 	"os/signal"
-	"path/filepath"
 
 	"strings"
 	"syscall"
@@ -346,17 +345,6 @@ func progressFromCmd(cmd *cobra.Command) (progress.ProgressBar, error) {
 	return progress.New(progressType)
 }
 
-// listOutputdir will return a string with the output dir content.
-// Any errors will also just appear as part of the string (as it is
-// purely informational)
-func listOutputdir(path string) string {
-	ents, err := filepath.Glob(filepath.Join(path, "/*"))
-	if err != nil {
-		return fmt.Sprintf("error: %v", err)
-	}
-	return strings.Join(ents, ",")
-}
-
 func cmdBuild(cmd *cobra.Command, args []string) error {
 	cacheDir, err := cmd.Flags().GetString("cache")
 	if err != nil {
@@ -449,7 +437,7 @@ func cmdBuild(cmd *cobra.Command, args []string) error {
 	}
 	pbar.Stop()
 
-	fmt.Fprintf(osStdout, "Image build successful, results:\n%s\n", listOutputdir(outputDir))
+	fmt.Fprintf(osStdout, "Image build successful: %s\n", imagePath)
 
 	if uploader != nil {
 		// XXX: integrate better into the progress, see bib

--- a/cmd/image-builder/main_test.go
+++ b/cmd/image-builder/main_test.go
@@ -387,9 +387,7 @@ func TestBuildIntegrationHappy(t *testing.T) {
 	})
 	assert.NoError(t, err)
 
-	assert.Contains(t, fakeStdout.String(), `Image build successful, results:
-centos-9-qcow2-x86_64/centos-9-qcow2-x86_64.qcow2
-`)
+	assert.Contains(t, fakeStdout.String(), `Image build successful: centos-9-qcow2-x86_64/centos-9-qcow2-x86_64.qcow2`)
 
 	// ensure osbuild was run exactly one
 	require.Equal(t, 1, len(fakeOsbuildCmd.CallArgsList()))


### PR DESCRIPTION
The success message simply lists the directory, however, this turns to be problematic when an existing directory was provided:

image-builder build ... --output-dir /mnt/images

Image build successful, results:
/mnt/images/a.qcow2,/mnt/images/b.qcow2,/mnt/images/c.qcow2

This patch changes the behavior to simply list the resulting artifact ignoring what is present in the directory.

---

I am aware that there was probably a reason why we list all the files, probably a log file can be present? Or a manifest? But I would rather list those artifacts explicitly, or make a note that there might be additional log file present or something like that then presenting a not very useful listing.