### PR TITLE
main: rename `data-dir` to `force-data-dir`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/osbuild/blueprint v1.18.0
 	github.com/osbuild/images v0.223.0
 	github.com/spf13/cobra v1.10.1
+	github.com/spf13/pflag v1.0.9
 	github.com/stretchr/testify v1.11.1
 	go.yaml.in/yaml/v3 v3.0.4
 	golang.org/x/sys v0.35.0
@@ -129,7 +130,6 @@ require (
 	github.com/sigstore/sigstore v1.9.5 // indirect
 	github.com/sirupsen/logrus v1.9.3 // indirect
 	github.com/smallstep/pkcs7 v0.1.1 // indirect
-	github.com/spf13/pflag v1.0.9 // indirect
 	github.com/stefanberger/go-pkcs11uri v0.0.0-20230803200340-78284954bff6 // indirect
 	github.com/sylabs/sif/v2 v2.21.1 // indirect
 	github.com/tchap/go-patricia/v2 v2.3.3 // indirect


### PR DESCRIPTION
Let's name arguments that fully override built-in definitions with the `force-` prefix. This makes room for an `extra-data-dir` in the future that allows for drop-in data.

The same will be applied to passing other arguments in the future.

We use a normalization to rename the old argument to the new one so we can keep accessing it under a single name and a deprecation to hide the previous argument name but still accept it on the command.

Cobra will emit a deprecation warning for us.

---

I'm planning to add a `--force-defs-dir` argument to make using YAML definitions a little bit more discoverable (though still experimental initially). This aligns nicely with the `--{force,extra}-repo` and we'd be consistent over all arguments, as we'll likely want drop-in definitions *and* full override capabilities.