### PR TITLE
Containerfile: add subscription-manager

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -18,7 +18,7 @@ RUN mkdir -p /etc/containers/networks
 # Fast-track osbuild so we don't depend on the "slow" Fedora release process to implement new features in bib
 RUN dnf install -y dnf-plugins-core \
     && dnf copr enable -y @osbuild/osbuild \
-    && dnf install -y libxcrypt-compat wget osbuild osbuild-ostree osbuild-depsolve-dnf osbuild-lvm2 openssl \
+    && dnf install -y libxcrypt-compat wget osbuild osbuild-ostree osbuild-depsolve-dnf osbuild-lvm2 openssl subscription-manager \
     && dnf clean all
 
 COPY --from=builder /build/image-builder /usr/bin/


### PR DESCRIPTION
By adding subscription-manager to the ibcli container we can install rhel content via the usual /run/secrets mechanism that podman supports, i.e. any subscribed system can do: `build <type> --distro rhel-10.1 ` and similar.

Closes https://issues.redhat.com/browse/HMS-9811