### PR TITLE
workflow: run build/cross-arch build in parallel 

### DIFF
--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -46,6 +46,12 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/testdeps
+      - name: Free Disk Space
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be
+        with:
+          tool-cache: true
+          # The following line runs apt remove which is slow
+          large-packages: false
       - name: Install integration test env
         run: |
           sudo apt update
@@ -60,6 +66,12 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/testdeps
+      - name: Free Disk Space
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be
+        with:
+          tool-cache: true
+          # The following line runs apt remove which is slow
+          large-packages: false
       - name: Install integration test env
         run: |
           sudo apt update


### PR DESCRIPTION
This commit moves the build and cross-arch build tests to
run in parallel. The tests take:
- cross-arch: 52min
- build: 22min

~We should see a nice speedup~ the wins are pretty small:

- cross-arch: 4 passed in 3033.26s (0:50:33)
- build: 4 passed in 3033.26s (0:50:33)

Not sure if that is worth it.