### PR TITLE
deps: update images to 0.228.0

### DIFF
--- a/cmd/image-builder/main_test.go
+++ b/cmd/image-builder/main_test.go
@@ -294,8 +294,8 @@ func TestManifestIntegrationOstreeSmokeErrors(t *testing.T) {
 			`options validation failed for image type "iot-raw-xz": ostree.url: required`,
 		},
 		{
-			[]string{"server-qcow2", "--ostree-url=http://example.com/"},
-			`OSTree is not supported for "server-qcow2"`,
+			[]string{"generic-qcow2", "--ostree-url=http://example.com/"},
+			`OSTree is not supported for "generic-qcow2"`,
 		},
 	} {
 		args := append(baseArgs, tc.extraArgs...)

--- a/cmd/image-builder/upload.go
+++ b/cmd/image-builder/upload.go
@@ -74,7 +74,7 @@ func uploaderCheckWithProgress(pbar progress.ProgressBar, uploader cloud.Uploade
 
 func uploaderFor(cmd *cobra.Command, typeOrCloud string, targetArch string, bootMode *platform.BootMode) (cloud.Uploader, error) {
 	switch typeOrCloud {
-	case "ami", "server-ami", "aws":
+	case "ami", "generic-ami", "aws":
 		return uploaderForCmdAWS(cmd, targetArch, bootMode)
 	case "libvirt":
 		return uploaderForLibvirt(cmd, targetArch, bootMode)
@@ -112,7 +112,7 @@ func uploaderForCmdAWS(cmd *cobra.Command, targetArchStr string, bootMode *platf
 			return nil, fmt.Errorf("Invalid tag format: %s (expected key=value)", tag)
 		}
 		slicedTags = append(slicedTags, awscloud.AWSTag{
-			Name: parts[0],
+			Name:  parts[0],
 			Value: parts[1],
 		})
 	}

--- a/cmd/image-builder/upload_test.go
+++ b/cmd/image-builder/upload_test.go
@@ -241,7 +241,7 @@ func TestBuildAndUploadFedoraWithAWSMock(t *testing.T) {
 		"--aws-region=aws-region-1",
 		"--aws-bucket=aws-bucket-2",
 		"--aws-ami-name=aws-ami-3",
-		"server-ami",
+		"generic-ami",
 		"--distro=fedora-43",
 	})
 	defer restore()

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/gobwas/glob v0.2.3
 	github.com/mattn/go-isatty v0.0.20
 	github.com/osbuild/blueprint v1.18.0
-	github.com/osbuild/images v0.226.0
+	github.com/osbuild/images v0.228.0
 	github.com/spf13/cobra v1.10.1
 	github.com/spf13/pflag v1.0.10
 	github.com/stretchr/testify v1.11.1

--- a/go.sum
+++ b/go.sum
@@ -289,8 +289,8 @@ github.com/opencontainers/selinux v1.12.0 h1:6n5JV4Cf+4y0KNXW48TLj5DwfXpvWlxXplU
 github.com/opencontainers/selinux v1.12.0/go.mod h1:BTPX+bjVbWGXw7ZZWUbdENt8w0htPSrlgOOysQaU62U=
 github.com/osbuild/blueprint v1.18.0 h1:Q95lRlPegoeb0uSgmY2yQK+oF8vZjmmxd61zRVdiBL0=
 github.com/osbuild/blueprint v1.18.0/go.mod h1:HPlJzkEl7q5g8hzaGksUk7ifFAy9QFw9LmzhuFOAVm4=
-github.com/osbuild/images v0.226.0 h1:NiryPkd+rx0iPFzKV7s/GP8HPuSuVyXDT2guWVx/i+k=
-github.com/osbuild/images v0.226.0/go.mod h1:Cs7zFV8rmbVHn+19ArNdjd1AtFk+LC9dOOHuxiSLghw=
+github.com/osbuild/images v0.228.0 h1:DL2W1tGkBcO0W5nS/NnVi6DaFDMNPBFI6zIoARZkXKE=
+github.com/osbuild/images v0.228.0/go.mod h1:Cs7zFV8rmbVHn+19ArNdjd1AtFk+LC9dOOHuxiSLghw=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=

--- a/test/test_build_cross.py
+++ b/test/test_build_cross.py
@@ -23,9 +23,9 @@ def test_build_cross_builds(tmp_path, build_container, arch):
         "build",
         "--progress=verbose",
         "--output-dir=/output",
-        "container",
+        "generic-container",
         "--distro", "fedora-43",
         # selecting a foreign arch here automatically triggers a cross-build
         f"--arch={arch}",
     ], text=True)
-    assert os.path.exists(output_dir / f"fedora-43-container-{arch}.tar")
+    assert os.path.exists(output_dir / f"fedora-43-generic-container-{arch}.tar")


### PR DESCRIPTION
This includes new Fedora image types (cloud, server) and a rename of the old types to (generic). This should bring parity to these artifacts as much as possible making `image-builder` a viable thing to build these images.

Also fixes a bug for Fedora ARM Minimal regarding kernel upgrades.