### PR TITLE
bib: drop inContainerOrUnknown() and use setup.IsContainer()

### DIFF
--- a/cmd/image-builder/bib_main.go
+++ b/cmd/image-builder/bib_main.go
@@ -6,7 +6,6 @@ import (
 	"io"
 	"io/fs"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"runtime/debug"
 	"strconv"
@@ -42,16 +41,6 @@ var (
 	osGetuid = os.Getuid
 	osGetgid = os.Getgid
 )
-
-func inContainerOrUnknown() bool {
-	// no systemd-detect-virt, err on the side of container
-	if _, err := exec.LookPath("systemd-detect-virt"); err != nil {
-		return true
-	}
-	// exit code "0" means the container is detected
-	err := exec.Command("systemd-detect-virt", "-c", "-q").Run()
-	return err == nil
-}
 
 func saveManifest(ms manifest.OSBuildManifest, fpath string) (err error) {
 	b, err := json.MarshalIndent(ms, "", "  ")
@@ -285,7 +274,7 @@ func bibCmdBuild(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("cannot validate the setup: %w", err)
 	}
 	logrus.Debug("Ensuring environment setup")
-	switch inContainerOrUnknown() {
+	switch setup.IsContainer() {
 	case false:
 		fmt.Fprintf(os.Stderr, "WARNING: running outside a container, this is an unsupported configuration\n")
 	case true:


### PR DESCRIPTION
[ported from https://github.com/osbuild/bootc-image-builder/pull/1111]

We have a shared helper now in ibcli, lets drop duplicated code. Thanks to Ondrej for writing the new (and better) helper.

