### PR TITLE
cmd: move `awscloudNewUploader` back into upload.go

### DIFF
--- a/cmd/image-builder/bib_main.go
+++ b/cmd/image-builder/bib_main.go
@@ -219,8 +219,6 @@ func bibCmdManifest(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-var awscloudNewUploader = awscloud.NewUploader
-
 func handleAWSFlags(cmd *cobra.Command) (cloud.Uploader, error) {
 	imgTypes, _ := cmd.Flags().GetStringArray("type")
 	region, _ := cmd.Flags().GetString("aws-region")

--- a/cmd/image-builder/upload.go
+++ b/cmd/image-builder/upload.go
@@ -31,9 +31,13 @@ var ErrUploadConfigNotProvided = errors.New("missing all upload configuration")
 // ErrUploadTypeUnsupported is returned when the upload type is not supported
 var ErrUploadTypeUnsupported = errors.New("unsupported type")
 
-var libvirtNewUploader = libvirt.NewUploader
-var openstackNewUploader = openstack.NewUploader
-var ibmNewUploader = ibmcloud.NewUploader
+// uploader constructors that are mocked in tests
+var (
+	awscloudNewUploader  = awscloud.NewUploader
+	libvirtNewUploader   = libvirt.NewUploader
+	openstackNewUploader = openstack.NewUploader
+	ibmNewUploader       = ibmcloud.NewUploader
+)
 
 func uploadImageWithProgress(uploader cloud.Uploader, imagePath string) error {
 	f, err := os.Open(imagePath)


### PR DESCRIPTION
During the merge of the bootc-image-builder code into bib (PR#374) a function accidentially moved from `upload.go` into `bib_main.go`. This was a mistake and this commit moves it back into the right place.

Thanks to Thozza for finding this [0]

[0] https://github.com/osbuild/image-builder-cli/pull/374#discussion_r2589121410