### PR TITLE
Rename server_url to server_hostname in registrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,8 +143,8 @@ $ cat > registrations.json <<EOF
     "subscription": {
       "activation_key": "replace-with_activation_key",
       "organization": "replace-with_org",
-      "server_url": "replace-with_server_url",
-      "base_url": "replace_with-base_url",
+      "server_hostname": "subscription.rhsm.redhat.com",
+      "base_url": "https://cdn.redhat.com",
       "insights": true,
       "rhc": true,
       "proxy": "replace-with_proxy"


### PR DESCRIPTION
I just noticed that we have a very misleading field name in registrations: `server_url`. This must not be URL, in fact, it breaks RHSM client it only accepts a hostname or IP:

```
[server]
hostname = subscription.rhsm.redhat.com

...

[rhsm]
baseurl = https://cdn.redhat.com
```

Base URL is correct.

I would like to fix this there is still time, tho, @achilleas-k already started using this in his monster CLI integration PR in composer. This draft does not anything yet, I want to discuss this how to approach this.

There are several options:

* Do nothing. :-)
* Keep it as URL and parse the value extracting only the hostname.
* Rename and break the contract.
* Rename but make a fallback unmarshaller that will accept the old field name as well.
* Other ideas.