### PR TITLE
main: error when image-builder is used to create anaconda-iso

### DIFF
--- a/cmd/image-builder/main.go
+++ b/cmd/image-builder/main.go
@@ -259,6 +259,13 @@ func cmdManifestWrapper(pbar progress.ProgressBar, cmd *cobra.Command, args []st
 
 	var img *imagefilter.Result
 	if bootcRef != "" {
+		// The behavior of anaconda-iso without special mTLS setup is different
+		// from bib so instead of introducing subtle incompatibilities just error
+		// here
+		if imgTypeStr == "anaconda-iso" {
+			return nil, fmt.Errorf(`image type bootc "anaconda-iso" is not supported with image-builder, please consider switching to "bootc-installer" or use bootc-image-builder`)
+		}
+
 		distro, err := bootc.NewBootcDistro(bootcRef, &bootc.DistroOptions{DefaultFs: bootcDefaultFs})
 		if err != nil {
 			return nil, err

--- a/cmd/image-builder/main_test.go
+++ b/cmd/image-builder/main_test.go
@@ -123,6 +123,21 @@ func TestListImagesErrorsOnExtraArgs(t *testing.T) {
 	assert.EqualError(t, err, `unknown command "extra-arg" for "image-builder list"`)
 }
 
+func TestBootcAnacondaIsoNotSupportedForImageBuilder(t *testing.T) {
+	restore := main.MockNewRepoRegistry(testrepos.New)
+	defer restore()
+
+	restore = main.MockOsArgs(append([]string{"manifest"}, "anaconda-iso", "--bootc-ref=example.com/cnt"))
+	defer restore()
+
+	var fakeStdout bytes.Buffer
+	restore = main.MockOsStdout(&fakeStdout)
+	defer restore()
+
+	err := main.Run()
+	assert.EqualError(t, err, `image type bootc "anaconda-iso" is not supported with image-builder, please consider switching to "bootc-installer" or use bootc-image-builder`)
+}
+
 func hasDepsolveDnf() bool {
 	// XXX: expose images/pkg/depsolve:findDepsolveDnf()
 	_, err := os.Stat("/usr/libexec/osbuild-depsolve-dnf")


### PR DESCRIPTION
The behavior of anaconda-iso without specil mTLS setup is different from bib so instead of introducing subtle incompatibilities just error.

Note that we could support this with something like: https://github.com/osbuild/image-builder-cli/compare/main...mvo5:consolidate-bib-anaconda-iso-wip?expand=1 but the general code that is currently fairly nice becomes not so nice anymore as we need to add a bunch of extra things like extracting mTLS, cleanup etc for an image-type we consider legacy and want to replace with the `bootc-installer` image type.