### PR TITLE
many: `force-repo-dir` instead of `force-data-dir`

### DIFF
--- a/cmd/image-builder/export_test.go
+++ b/cmd/image-builder/export_test.go
@@ -49,9 +49,9 @@ func MockOsStderr(new io.Writer) (restore func()) {
 
 func MockNewRepoRegistry(f func() (*reporegistry.RepoRegistry, error)) (restore func()) {
 	saved := newRepoRegistry
-	newRepoRegistry = func(dataDir string, extraRepos []string) (*reporegistry.RepoRegistry, error) {
-		if dataDir != "" {
-			panic(fmt.Sprintf("cannot use custom dataDir %v in mock", dataDir))
+	newRepoRegistry = func(repoDir string, extraRepos []string) (*reporegistry.RepoRegistry, error) {
+		if repoDir != "" {
+			panic(fmt.Sprintf("cannot use custom repoDir %v in mock", repoDir))
 		}
 		return f()
 	}

--- a/cmd/image-builder/filters.go
+++ b/cmd/image-builder/filters.go
@@ -10,9 +10,9 @@ import (
 	"github.com/osbuild/images/pkg/imagefilter"
 )
 
-func newImageFilterDefault(dataDir string, extraRepos []string) (*imagefilter.ImageFilter, error) {
+func newImageFilterDefault(repoDir string, extraRepos []string) (*imagefilter.ImageFilter, error) {
 	fac := distrofactory.NewDefault()
-	repos, err := newRepoRegistry(dataDir, extraRepos)
+	repos, err := newRepoRegistry(repoDir, extraRepos)
 	if err != nil {
 		return nil, err
 	}
@@ -21,8 +21,9 @@ func newImageFilterDefault(dataDir string, extraRepos []string) (*imagefilter.Im
 }
 
 type repoOptions struct {
-	// DataDir contains the base dir for the repo definition search path
-	DataDir string
+	// RepoDir contains the base dir for the repo definition search path, it will also look
+	// in the `repositories` subdirectory to RepoDir
+	RepoDir string
 
 	// ExtraRepos contains extra baseURLs that get added to the depsolving
 	ExtraRepos []string
@@ -37,7 +38,7 @@ func getOneImage(distroName, imgTypeStr, archStr string, repoOpts *repoOptions) 
 		repoOpts = &repoOptions{}
 	}
 
-	imageFilter, err := newImageFilterDefault(repoOpts.DataDir, repoOpts.ExtraRepos)
+	imageFilter, err := newImageFilterDefault(repoOpts.RepoDir, repoOpts.ExtraRepos)
 	if err != nil {
 		return nil, err
 	}
@@ -83,7 +84,7 @@ func getAllImages(repoOpts *repoOptions, filterExprs ...string) ([]imagefilter.R
 		repoOpts = &repoOptions{}
 	}
 
-	imageFilter, err := newImageFilterDefault(repoOpts.DataDir, repoOpts.ExtraRepos)
+	imageFilter, err := newImageFilterDefault(repoOpts.RepoDir, repoOpts.ExtraRepos)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/image-builder/list.go
+++ b/cmd/image-builder/list.go
@@ -4,8 +4,8 @@ import (
 	"github.com/osbuild/images/pkg/imagefilter"
 )
 
-func listImages(dataDir string, extraRepos []string, output string, filterExprs []string) error {
-	imageFilter, err := newImageFilterDefault(dataDir, extraRepos)
+func listImages(repoDir string, extraRepos []string, output string, filterExprs []string) error {
+	imageFilter, err := newImageFilterDefault(repoDir, extraRepos)
 	if err != nil {
 		return err
 	}

--- a/cmd/image-builder/manifest.go
+++ b/cmd/image-builder/manifest.go
@@ -57,8 +57,8 @@ func sbomWriter(outputDir, filename string, content io.Reader) error {
 }
 
 // XXX: just return []byte instead of using output writer
-func generateManifest(dataDir string, extraRepos []string, img *imagefilter.Result, output io.Writer, opts *manifestOptions) error {
-	repos, err := newRepoRegistry(dataDir, extraRepos)
+func generateManifest(repoDir string, extraRepos []string, img *imagefilter.Result, output io.Writer, opts *manifestOptions) error {
+	repos, err := newRepoRegistry(repoDir, extraRepos)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Previously I deprecated `data-dir` and renamed it to `force-data-dir` to have consistent naming for options that overwrite internal state instead of appending to it (arguments that start with `force-` are overwrites, arguments that start with `extra-` are merges).

With `force-data-dir` we require a `repositories` sub directory. After some discussion we came to the idea to instead of enforcing a directory layout on the user we want to be able to point directly at a directory of repositories.

This commit deprecates `force-data-dir` and introduces `force-repo-dir`. Both write to the same internal variable.

We also allow repository files to live *either* in a `repositories` subdirectory to keep backwards compatibility for any of the arguments or to live directly at the top level of the passed directory.

We show a deprecation warning if a `repositories` sub directory exists and inform users that the `repositories` subdirectory will not be wanted in the future and how to resolve the emitted warning.

This option will be used together with the future introduction of `force-defs-dir` to handle definitions (and its `extra-defs-dir` counter part) unifying all options into a consistent naming scheme.