### PR TITLE
data: install tmpfiles.d/image-builder.conf to auto-clean cache

### DIFF
--- a/data/tmpfiles.d/image-builder.conf
+++ b/data/tmpfiles.d/image-builder.conf
@@ -1,0 +1,2 @@
+# Type  Path                        Mode UID  GID  Age
+d       /var/cache/image-builder    0755 root root 14d

--- a/image-builder.spec
+++ b/image-builder.spec
@@ -42,6 +42,8 @@ BuildRequires:  libvirt-devel
 %if 0%{?fedora}
 # Build requirements of 'github.com/containers/storage' package
 BuildRequires:  btrfs-progs-devel
+# for _tmpfilesdir macro
+BuildRequires:  systemd-rpm-macros
 # DO NOT REMOVE the BUNDLE_START and BUNDLE_END markers as they are used by 'tools/rpm_spec_add_provides_bundle.sh' to generate the Provides: bundled list
 # BUNDLE_START
 # BUNDLE_END
@@ -93,7 +95,9 @@ export LDFLAGS="${LDFLAGS} -X 'main.version=%{version}'"
 %install
 install -m 0755 -vd                                 %{buildroot}%{_bindir}
 install -m 0755 -vp %{gobuilddir}/bin/image-builder %{buildroot}%{_bindir}/
-
+# tmpfiles.d snippet
+install -m 0755 -vd                                 %{buildroot}%{_tmpfilesdir}
+install -m 0644 -vp data/tmpfiles.d/image-builder.conf %{buildroot}%{_tmpfilesdir}/image-builder.conf
 %check
 export GOFLAGS="-buildmode=pie"
 %if 0%{?rhel}
@@ -110,6 +114,8 @@ cd $PWD/_build/src/%{goipath}
 %license LICENSE
 %doc README.md
 %{_bindir}/image-builder
+%{_tmpfilesdir}/image-builder.conf
+%ghost %dir /var/cache/image-builder
 
 %changelog
 # the changelog is distribution-specific, therefore there's just one entry


### PR DESCRIPTION
Our osbuild/image-builder cache is located in /var/cache/image-builder and it can grow quite big. To avoid it growing out of bounds too much add a tmpfile.d snippet to ensure that we clean content older than 14d. The 14d is a bit arbitrary, happy to change to longer or shorter cache timeouts (side-note: we have a cache limit in osbuild and an LRU there too but sources are currently not part of the cache limits in osbuild).