### PR TITLE
ci: gobump blueprint separately

### DIFF
--- a/.github/workflows/gobump.yaml
+++ b/.github/workflows/gobump.yaml
@@ -19,7 +19,7 @@ jobs:
         with:
           go_version: "1.23.9"
           token: ${{ secrets.SCHUTZBOT_GITHUB_ACCESS_TOKEN }}
-          include: "github.com/osbuild/images"
+          include: "github.com/osbuild/images github.com/osbuild/blueprint"
           commit_message: "deps: bump osbuild/images dependency"
 
       - name: Cleaup repository
@@ -30,5 +30,5 @@ jobs:
         with:
           go_version: "1.23.9"
           token: ${{ secrets.SCHUTZBOT_GITHUB_ACCESS_TOKEN }}
-          exclude: "github.com/osbuild/images"
+          exclude: "github.com/osbuild/images,github.com/osbuild/blueprint"
           commit_message: "deps: update dependencies (w/o osbuild/images)"


### PR DESCRIPTION
Both images and blueprint need to be bumped separately.

---

This ensures breaking changes are pulled out of regular weekly bumps.

For the record, excluding is a command line option and is comma separated while including is passed as space-separated arguments. That is how gobump CLI works.