### PR TITLE
deps: bump images to 0.231.0

### DIFF
--- a/cmd/image-builder/describeimg_test.go
+++ b/cmd/image-builder/describeimg_test.go
@@ -67,7 +67,6 @@ blueprint:
     - groups
     - containers
     - enabled_modules
-    - minimal
     - customizations.dnf
     - customizations.cacerts
     - customizations.directories

--- a/doc/01-usage.md
+++ b/doc/01-usage.md
@@ -204,15 +204,14 @@ RUN dnf install -y \
      biosdevname \
      prefixdevname \
      && dnf clean all
-# shim-x64 is marked installed but the files are not in the expected
-# place for https://github.com/osbuild/osbuild/blob/v160/stages/org.osbuild.grub2.iso#L91, see
-# workaround via reinstall, we could add a config to the grub2.iso
-# stage to allow a different prefix that then would be used by
-# anaconda.
-# once https://github.com/osbuild/osbuild/pull/2202 is merged we
-# can update images/ to set the correct efi_src_dir and this can
-# be removed
-RUN dnf reinstall -y shim-x64
+
+# On Fedora 42 this is necessary to get files in the right places
+# RUN dnf reinstall -y shim-x64
+
+# On Fedora 43 and up this is necessary to get files in the right
+# places
+RUN mkdir -p /boot/efi && cp -ra /usr/lib/efi/*/*/EFI /boot/efi
+
 # lorax wants to create a symlink in /mnt which points to /var/mnt
 # on bootc but /var/mnt does not exist on some images.
 #

--- a/go.mod
+++ b/go.mod
@@ -11,8 +11,8 @@ require (
 	github.com/cheggaaa/pb/v3 v3.1.7
 	github.com/gobwas/glob v0.2.3
 	github.com/mattn/go-isatty v0.0.20
-	github.com/osbuild/blueprint v1.18.0
-	github.com/osbuild/images v0.228.0
+	github.com/osbuild/blueprint v1.20.0
+	github.com/osbuild/images v0.231.0
 	github.com/sirupsen/logrus v1.9.3
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/pflag v1.0.10

--- a/go.sum
+++ b/go.sum
@@ -287,10 +287,10 @@ github.com/opencontainers/runtime-spec v1.2.1 h1:S4k4ryNgEpxW1dzyqffOmhI1BHYcjzU
 github.com/opencontainers/runtime-spec v1.2.1/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/C5hL+LL3ko9hs6T5lQ0=
 github.com/opencontainers/selinux v1.12.0 h1:6n5JV4Cf+4y0KNXW48TLj5DwfXpvWlxXplUkdTrmPb8=
 github.com/opencontainers/selinux v1.12.0/go.mod h1:BTPX+bjVbWGXw7ZZWUbdENt8w0htPSrlgOOysQaU62U=
-github.com/osbuild/blueprint v1.18.0 h1:Q95lRlPegoeb0uSgmY2yQK+oF8vZjmmxd61zRVdiBL0=
-github.com/osbuild/blueprint v1.18.0/go.mod h1:HPlJzkEl7q5g8hzaGksUk7ifFAy9QFw9LmzhuFOAVm4=
-github.com/osbuild/images v0.228.0 h1:DL2W1tGkBcO0W5nS/NnVi6DaFDMNPBFI6zIoARZkXKE=
-github.com/osbuild/images v0.228.0/go.mod h1:Cs7zFV8rmbVHn+19ArNdjd1AtFk+LC9dOOHuxiSLghw=
+github.com/osbuild/blueprint v1.20.0 h1:O1FzTXhCxxwquROttv2nC827JYUJCT0rLypAltV2MpM=
+github.com/osbuild/blueprint v1.20.0/go.mod h1:HPlJzkEl7q5g8hzaGksUk7ifFAy9QFw9LmzhuFOAVm4=
+github.com/osbuild/images v0.231.0 h1:QbjOqC777TfdE5KNco9r+XgBvBn0NPoglUPZPaQxTos=
+github.com/osbuild/images v0.231.0/go.mod h1:04grrQg/kMDXFysqFxQNQSNGvKFdzlf6NM7k15gPiCo=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=

--- a/test/test_manifest.py
+++ b/test/test_manifest.py
@@ -146,7 +146,7 @@ def test_container_manifest_bootc_iso_smoke(build_container):
                        if st["type"] == "org.osbuild.kickstart"][0]
     assert re.match(
         f'bootc switch .* registry {bootc_payload_ref}',
-        kickstart_stage["options"]["%post"][0]["commands"][0])
+        kickstart_stage["options"]["%post"][0]["commands"][1])
 
 
 def test_manifest_honors_rpmmd_cache(tmp_path, build_container):


### PR DESCRIPTION
Updates images. This (partially) resolves an issue [1] we were seeing. We also need a new workaround for files being in the right places for Fedora 43 and up due to this commit [2] in `bootupd`.

Also adjust a test since the `minimal` customization was dropped. Adjust another test to search through the entire kickstart as we added a `set -e`.

[1]: https://github.com/osbuild/image-builder-cli/issues/421
[2]: https://github.com/coreos/bootupd/commit/1c02bc75ac228867ab4e077b8f4bafda6ceb31dc