### PR TITLE
spec: Use gosource macro for Source0

### DIFF
--- a/image-builder.spec
+++ b/image-builder.spec
@@ -27,7 +27,7 @@ ExcludeArch:    i686
 License:        Apache-2.0 AND BSD-2-Clause AND BSD-3-Clause AND CC-BY-SA-4.0 AND ISC AND MIT AND MPL-2.0 AND Unlicense
 
 URL:            %{gourl}
-Source0:        https://github.com/osbuild/image-builder-cli/releases/download/v%{version}/image-builder-cli-%{version}.tar.gz
+Source0:        %{gosource}
 
 
 BuildRequires:  %{?go_compiler:compiler(go-compiler)}%{!?go_compiler:golang}


### PR DESCRIPTION
This fixes #419, allowing 'make srpm', 'make rpm' and 'make scratch' to work.