### PR TITLE
deps: bump

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,8 +11,8 @@ require (
 	github.com/cheggaaa/pb/v3 v3.1.7
 	github.com/gobwas/glob v0.2.3
 	github.com/mattn/go-isatty v0.0.20
-	github.com/osbuild/blueprint v1.21.0
-	github.com/osbuild/images v0.231.0
+	github.com/osbuild/blueprint v1.22.0
+	github.com/osbuild/images v0.233.0
 	github.com/sirupsen/logrus v1.9.3
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/pflag v1.0.10

--- a/go.sum
+++ b/go.sum
@@ -287,10 +287,10 @@ github.com/opencontainers/runtime-spec v1.2.1 h1:S4k4ryNgEpxW1dzyqffOmhI1BHYcjzU
 github.com/opencontainers/runtime-spec v1.2.1/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/C5hL+LL3ko9hs6T5lQ0=
 github.com/opencontainers/selinux v1.12.0 h1:6n5JV4Cf+4y0KNXW48TLj5DwfXpvWlxXplUkdTrmPb8=
 github.com/opencontainers/selinux v1.12.0/go.mod h1:BTPX+bjVbWGXw7ZZWUbdENt8w0htPSrlgOOysQaU62U=
-github.com/osbuild/blueprint v1.21.0 h1:H/ZhoUjbzAJIgZweSRPUEiegQoJ/nLA6WRJS+FvsZpk=
-github.com/osbuild/blueprint v1.21.0/go.mod h1:HPlJzkEl7q5g8hzaGksUk7ifFAy9QFw9LmzhuFOAVm4=
-github.com/osbuild/images v0.231.0 h1:QbjOqC777TfdE5KNco9r+XgBvBn0NPoglUPZPaQxTos=
-github.com/osbuild/images v0.231.0/go.mod h1:04grrQg/kMDXFysqFxQNQSNGvKFdzlf6NM7k15gPiCo=
+github.com/osbuild/blueprint v1.22.0 h1:b3WicGjCFzEwOm/YwPH7w9YioCcehGejdOTkjJ3Fyz0=
+github.com/osbuild/blueprint v1.22.0/go.mod h1:HPlJzkEl7q5g8hzaGksUk7ifFAy9QFw9LmzhuFOAVm4=
+github.com/osbuild/images v0.233.0 h1:T/9GDXnxBqDEPWOu0OIxzorp7fBtBb9sc1R/Kt8CuEo=
+github.com/osbuild/images v0.233.0/go.mod h1:vjzHaL/8MDG6c3yjU8qgMKOIib89A1r2ql50Nronaw4=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=

--- a/image-builder.spec
+++ b/image-builder.spec
@@ -3,7 +3,7 @@
 # required. So if this needs backport to places where there is no
 # recent osbuild available we could simply make --use-librepo false
 # and go back to 129.
-%global min_osbuild_version 163
+%global min_osbuild_version 167
 
 %global goipath         github.com/osbuild/image-builder-cli
 


### PR DESCRIPTION
Bump `images` to `0.233.0`, bump `blueprint` to `1.22.0`. The former is necessary to recognize Fedora 45 which branches soon-ish.