### PR TITLE
Revert "spec: Use gosource macro for Source0"

### DIFF
--- a/image-builder.spec
+++ b/image-builder.spec
@@ -27,7 +27,7 @@ ExcludeArch:    i686
 License:        Apache-2.0 AND BSD-2-Clause AND BSD-3-Clause AND CC-BY-SA-4.0 AND ISC AND MIT AND MPL-2.0 AND Unlicense
 
 URL:            %{gourl}
-Source0:        %{gosource}
+Source0:        https://github.com/osbuild/image-builder-cli/releases/download/v%{version}/image-builder-cli-%{version}.tar.gz
 
 
 BuildRequires:  %{?go_compiler:compiler(go-compiler)}%{!?go_compiler:golang}


### PR DESCRIPTION
This reverts commit 06f9d2e8c623b2e5c8d8a83b270416f3236d3035. It causes build failures downstream such as [1] due to (probably?) the vendored dependencies not being available.

[1]: https://koji.fedoraproject.org/koji/taskinfo?taskID=141120275