### PR TITLE
cicd: allow pytest to be triggered manually

### DIFF
--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -7,6 +7,12 @@ on:  # yamllint disable-line rule:truthy
     branches: ["main"]
   merge_group:
     types: ["checks_requested"]
+  workflow_dispatch:
+    inputs:
+      reason:
+        description: 'Reason for running'
+        required: false
+        default: 'No reason provided'
 
 jobs:
   lint:


### PR DESCRIPTION
SSIA

A PR with red test was merged recently and I would like to be see if that was a random issue or not. Locally it passes fine.

https://github.com/osbuild/image-builder-cli/pull/436/files