### PR TITLE
chore: fix constant format string

### DIFF
--- a/pkg/progress/command.go
+++ b/pkg/progress/command.go
@@ -186,7 +186,7 @@ func runOSBuildWithProgress(pb ProgressBar, manifest []byte, exports []string, o
 		}
 		// forward to user
 		if st.Message != "" {
-			pb.SetMessagef(st.Message)
+			pb.SetMessagef("%s", st.Message)
 		}
 
 		// keep internal log for error reporting, forward to


### PR DESCRIPTION
Downstream tests run go vet and this errors about the non-constant format string being used here.