### PR TITLE
Containerfile*: remove the GOPROXY override

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -1,7 +1,5 @@
 FROM registry.fedoraproject.org/fedora:43 AS builder
 RUN dnf install -y git-core golang gpgme-devel libassuan-devel && mkdir -p /build/
-ARG GOPROXY=https://proxy.golang.org,direct
-RUN go env -w GOPROXY=$GOPROXY
 WORKDIR /build
 COPY go.mod go.sum ./
 RUN go mod download

--- a/Containerfile.bib
+++ b/Containerfile.bib
@@ -1,8 +1,6 @@
 FROM registry.fedoraproject.org/fedora:43 AS builder
 RUN dnf install -y git-core golang gpgme-devel libassuan-devel libvirt-devel && mkdir -p /build/bib
 COPY go.mod go.sum /build/bib/
-ARG GOPROXY=https://proxy.golang.org,direct
-RUN go env -w GOPROXY=$GOPROXY
 RUN cd /build/bib && go mod download
 # Copy the entire dir to avoid having to conditionally include ".git" as that
 # will not be available when tests are run under tmt

--- a/devel/Containerfile
+++ b/devel/Containerfile
@@ -1,7 +1,5 @@
 FROM registry.fedoraproject.org/fedora:43 AS builder
 RUN dnf install -y git-core golang gpgme-devel libassuan-devel libvirt-devel && mkdir -p /build/bib
-ARG GOPROXY=https://proxy.golang.org,direct
-RUN go env -w GOPROXY=$GOPROXY
 ## Run with --build-context=images=../images to build with local changes
 COPY --from=images . /images
 COPY . /build


### PR DESCRIPTION
Fedora 43 reverted the patch to use GOPROXY=direct, and it now follows the standard https://proxy.golang.org,direct, so we can remove it from our Containerfiles.

See https://fedoraproject.org/wiki/Changes/golang1.25