### PR TITLE
verbose logging fixes

### DIFF
--- a/cmd/image-builder/main.go
+++ b/cmd/image-builder/main.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 	"syscall"
 
+	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 
@@ -655,7 +656,11 @@ operating systems like Fedora, CentOS and RHEL with easy customizations support.
 		if verbose {
 			olog.SetDefault(log.New(os.Stderr, "", 0))
 			olog.Print("verbose logging enabled")
-			// XXX: add once images has olog support
+			// osbuild/images still partially uses logrus, so enable it here as well
+			logrus.SetLevel(logrus.DebugLevel)
+			logrus.SetOutput(os.Stderr)
+			logrus.Debug("legacy logrus logging enabled")
+			// XXX: add once images has olog support, and drop logrus
 			//images_log.SetDefault(log.New(os.Stderr, "", 0))
 		}
 		return nil


### PR DESCRIPTION
2 commits meant for fixing, and improving the `--verbose` mode. Turns out it didn't work at all before.

**main: fix --verbose logging**

rootCmd.PersistentFlags().GetBool("verbose") always returned false prior
this commit because flags are not parse yet. This happens only when
rootCmd.Execute() is called.

Fix this by using one of the cobra hooks that runs after flags are
parsed. Note that the hook is needed because we want to enable verbose
logging for all subcommands. Otherwise, we would have to enable it in
every single subcommand.

I also added a small log message that actually informs users that
verbose logging is enabled.

---

**main: enable logrus in --verbose mode**

osbuild/images still use logrus for some its logging, so let's enable it
as well until we can fully migrate over.