### PR TITLE
go.mod: update osbuild/images to v0.238.0 (HMS-9090)

### DIFF
--- a/Schutzfile
+++ b/Schutzfile
@@ -2,7 +2,7 @@
   "common": {
     "dependencies": {
       "osbuild": {
-        "commit": "6c34e00bedd8101293382f2d563d111825b46349"
+        "commit": "ef5fcda4ae0d0e6957b55fe965317007496432c9"
       }
     }
   }

--- a/go.mod
+++ b/go.mod
@@ -11,8 +11,8 @@ require (
 	github.com/cheggaaa/pb/v3 v3.1.7
 	github.com/gobwas/glob v0.2.3
 	github.com/mattn/go-isatty v0.0.20
-	github.com/osbuild/blueprint v1.22.0
-	github.com/osbuild/images v0.236.0
+	github.com/osbuild/blueprint v1.23.0
+	github.com/osbuild/images v0.238.0
 	github.com/sirupsen/logrus v1.9.4
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/pflag v1.0.10

--- a/go.sum
+++ b/go.sum
@@ -287,10 +287,10 @@ github.com/opencontainers/runtime-spec v1.2.1 h1:S4k4ryNgEpxW1dzyqffOmhI1BHYcjzU
 github.com/opencontainers/runtime-spec v1.2.1/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/C5hL+LL3ko9hs6T5lQ0=
 github.com/opencontainers/selinux v1.12.0 h1:6n5JV4Cf+4y0KNXW48TLj5DwfXpvWlxXplUkdTrmPb8=
 github.com/opencontainers/selinux v1.12.0/go.mod h1:BTPX+bjVbWGXw7ZZWUbdENt8w0htPSrlgOOysQaU62U=
-github.com/osbuild/blueprint v1.22.0 h1:b3WicGjCFzEwOm/YwPH7w9YioCcehGejdOTkjJ3Fyz0=
-github.com/osbuild/blueprint v1.22.0/go.mod h1:HPlJzkEl7q5g8hzaGksUk7ifFAy9QFw9LmzhuFOAVm4=
-github.com/osbuild/images v0.236.0 h1:roC5fEFCs2mFYFNDvnK8mRiN4XGJ28erx7kLpqI3dv8=
-github.com/osbuild/images v0.236.0/go.mod h1:vjzHaL/8MDG6c3yjU8qgMKOIib89A1r2ql50Nronaw4=
+github.com/osbuild/blueprint v1.23.0 h1:HGMuRKpYg2xBy1QnAQDaIM6xnmzXh4QBrjic86C6Xr8=
+github.com/osbuild/blueprint v1.23.0/go.mod h1:HPlJzkEl7q5g8hzaGksUk7ifFAy9QFw9LmzhuFOAVm4=
+github.com/osbuild/images v0.238.0 h1:qJnMZOgtuoSJrXdSzyqDm+h5qw+cKK+oJIQFEG7W7LU=
+github.com/osbuild/images v0.238.0/go.mod h1:3/nKlYk9W8bsgrb8svP0j4q8/LlqY4F12eAqUgLLo5c=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=

--- a/image-builder.spec
+++ b/image-builder.spec
@@ -3,7 +3,7 @@
 # required. So if this needs backport to places where there is no
 # recent osbuild available we could simply make --use-librepo false
 # and go back to 129.
-%global min_osbuild_version 170
+%global min_osbuild_version 171
 
 %global goipath         github.com/osbuild/image-builder-cli
 


### PR DESCRIPTION
Among other things, this brings the multi-stage RPM installation, which solves the bug with installation of packages that use %pretrans sctiptlet.

```
Changes with 0.237.0

----------------
  - Add ResolveInfo() function for resolving all bootc container info in one call (#2151)
    - Author: Achilleas Koutsou, Reviewers: Brian C. Lane, Simon de Vlieger
  - Use cpio -H newc instead of -c (#2153)
    - Author: Brian C. Lane, Reviewers: Lukáš Zapletal, Tomáš Hozza
  - bootc-generic-iso: add container embedding (#2138)
    - Author: Ondřej Budai, Reviewers: Lukáš Zapletal, Simon de Vlieger
  - check: implement file/dir/kernel host checks (#2142)
    - Author: Lukáš Zapletal, Reviewers: Ondřej Budai, Tomáš Hozza
  - go.mod: update osbuild/blueprint (#2148)
    - Author: Achilleas Koutsou, Reviewers: Lukáš Zapletal, Simon de Vlieger
  - osinfo, bootc: allow (some) configuration for generic `bootc-iso` through an `iso.yaml` in the container (HMS-10018, HMS-10015) (#2135)
    - Author: Simon de Vlieger, Reviewers: Achilleas Koutsou, Lukáš Zapletal

— Somewhere on the Internet, 2026-02-02

---

Changes with 0.238.0

----------------
  - Refactor RPM installation to use multi-stage transactions for %pretrans script support (HMS-9090) (#2170)
    - Author: Tomáš Hozza, Reviewers: Sanne Raymaekers, Simon de Vlieger
  - Update osbuild dependency commit ID (#2166)
    - Author: SchutzBot, Reviewers: Achilleas Koutsou, Simon de Vlieger, Tomáš Koscielniak
  - bib: ban logrus from the project (#2162)
    - Author: Lukáš Zapletal, Reviewers: Brian C. Lane, Sanne Raymaekers, Simon de Vlieger
  - checks/kernel: convert option failure to warning (#2173)
    - Author: Achilleas Koutsou, Reviewers: Simon de Vlieger, Tomáš Hozza
  - distro: `ImageOptions.Preview` (HMS-9969) (#2174)
    - Author: Simon de Vlieger, Reviewers: Achilleas Koutsou, Lukáš Zapletal
  - manifest/subscription: fix selinux systemd race condition (HMS-10142) (#2171)
    - Author: Gianluca Zuccarelli, Reviewers: Achilleas Koutsou, Tomáš Hozza
  - rhsm_facts: Add blueprint-id as optional fact (HMS-3881) (#2163)
    - Author: Simon Steinbeiß, Reviewers: Lukáš Zapletal, Tomáš Hozza

— Somewhere on the Internet, 2026-02-05
```