### PR TITLE
main: provide `--preview` to toggle preview state (HMS-9969)

### DIFF
--- a/cmd/image-builder/main.go
+++ b/cmd/image-builder/main.go
@@ -197,6 +197,18 @@ func cmdManifestWrapper(pbar progress.ProgressBar, cmd *cobra.Command, args []st
 	if err != nil {
 		return nil, err
 	}
+	var preview *bool
+	// Verify that the flag was actually passed. If it wasn't passed
+	// we keep our nil value so that images used the distro-defined
+	// value for preview. Otherwise use the provided value so the
+	// distro value gets overridden.
+	if cmd.Flags().Lookup("preview").Changed {
+		value, err := cmd.Flags().GetBool("preview")
+		if err != nil {
+			return nil, err
+		}
+		preview = &value
+	}
 	var rpmDownloader osbuild.RpmDownloader
 	if useLibrepo {
 		rpmDownloader = osbuild.RpmDownloaderLibrepo
@@ -324,6 +336,7 @@ func cmdManifestWrapper(pbar progress.ProgressBar, cmd *cobra.Command, args []st
 		WithSBOM:                 withSBOM,
 		IgnoreWarnings:           ignoreWarnings,
 		Subscription:             subscription,
+		Preview:                  preview,
 
 		ForceRepos: forceRepos,
 	}
@@ -588,6 +601,8 @@ operating systems like Fedora, CentOS and RHEL with easy customizations support.
 	manifestCmd.Flags().Bool("ignore-warnings", false, `ignore warnings during manifest generation`)
 	manifestCmd.Flags().String("registrations", "", `filename of a registrations file with e.g. subscription details`)
 	manifestCmd.Flags().String("rpmmd-cache", "", `osbuild directory to cache rpm metadata`)
+	manifestCmd.Flags().Bool("preview", true, `override distro default preview state if passed`)
+	manifestCmd.Flags().MarkHidden("preview")
 	rootCmd.AddCommand(manifestCmd)
 
 	uploadCmd := &cobra.Command{

--- a/cmd/image-builder/manifest.go
+++ b/cmd/image-builder/manifest.go
@@ -34,6 +34,7 @@ type manifestOptions struct {
 	RpmDownloader            osbuild.RpmDownloader
 	WithSBOM                 bool
 	IgnoreWarnings           bool
+	Preview                  *bool
 
 	ForceRepos []string
 }
@@ -98,6 +99,7 @@ func generateManifest(repoDir string, extraRepos []string, img *imagefilter.Resu
 		Bootc: &distro.BootcImageOptions{
 			InstallerPayloadRef: opts.BootcInstallerPayloadRef,
 		},
+		Preview: opts.Preview,
 	}
 
 	mf, err := mg.Generate(bp, img.ImgType, imgOpts)


### PR DESCRIPTION
```
main: provide `--preview` to toggle preview state

Certain image types have the notion of being in a preview state. Also
called "final", "supported", or "prerelease".

In `images`'s distribution definitions we define this flag per version
of a distribution. This means that we need to quickly do releases to
update this value before a release candidate is built (release
candidates are built as "supported").

When pungi schedules composes it knows the supported state of the
compose. Thus it is a good idea to let the preview state of a
distro be overridden by the `pungi` -> `koji` -> `image-builder`
chain.

Let's include a `--preview` argument. When the option is not passed at
all we let `images` determine the preview state (based on its
distribution definitions). When the option is passed we pass along its
value to `images` where it is then used instead of the default.

I've kept the option hidden here because it really only should be used
by build systems or advanced users (we might document its use) and not
confuse normal users; who would usually receive new distribution
definitions with the next `image-builder` release which contain the
correct preview state, though it will lag a bit in time.
```

This PR is based on top of #448.

I thought a bit about naming the option in a specific way that would indicate that this is an image option; however, we don't do so for other things that get passed as image options and I don't foresee this name clashing with anything else.

After this is done follow-up work is necessary in `koji-image-builder` and `pungi` itself to be able to pass this argument along.

Examples:

```
€ ./image-builder manifest --distro fedora-44 everything-network-installer 2>/dev/null | rg final
                        "final": false,
€ ./image-builder manifest --distro fedora-44 --preview=true everything-network-installer 2>/dev/null | rg final
                        "final": false,
€ ./image-builder manifest --distro fedora-44 --preview=false everything-network-installer 2>/dev/null | rg final
                        "final": true,
€ ./image-builder manifest --distro fedora-44 --preview everything-network-installer 2>/dev/null | rg final 
                        "final": false,
```