### PR TITLE
SPEC: define default permissions for /var/cache/image-builder

### DIFF
--- a/image-builder.spec
+++ b/image-builder.spec
@@ -115,7 +115,7 @@ cd $PWD/_build/src/%{goipath}
 %doc README.md
 %{_bindir}/image-builder
 %{_tmpfilesdir}/image-builder.conf
-%ghost %dir /var/cache/image-builder
+%ghost %attr(0755, root, root) %dir /var/cache/image-builder
 
 %changelog
 # the changelog is distribution-specific, therefore there's just one entry


### PR DESCRIPTION
Not defining the permissions makes 'rpm --verify' complain, because it expects the directory to have no permissions at all.

```
$ rpm -qlv image-builder | grep /var/cache/image-builder
d---------    2 root     root                        0 úno  6 01:00 /var/cache/image-builder
```

```
$ rpm --verify image-builder
.M.......  g /var/cache/image-builder
```

Define the default expected permissions for the directory.

This is needed to fix downstream c9s CI test installability failure.