### PR TITLE
bootc: Bump images to v0.242.0 and adjust bootc for changes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/gobwas/glob v0.2.3
 	github.com/mattn/go-isatty v0.0.20
 	github.com/osbuild/blueprint v1.23.0
-	github.com/osbuild/images v0.240.0
+	github.com/osbuild/images v0.242.0
 	github.com/sirupsen/logrus v1.9.4
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/pflag v1.0.10


### PR DESCRIPTION
The bootc container references need to be resolved into bootc.Info structs before being passed to generic.NewBootc