### PR TITLE
go.mod: update osbuild/images to v0.240.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/gobwas/glob v0.2.3
 	github.com/mattn/go-isatty v0.0.20
 	github.com/osbuild/blueprint v1.23.0
-	github.com/osbuild/images v0.238.0
+	github.com/osbuild/images v0.240.0
 	github.com/sirupsen/logrus v1.9.4
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/pflag v1.0.10

--- a/go.sum
+++ b/go.sum
@@ -289,8 +289,8 @@ github.com/opencontainers/selinux v1.12.0 h1:6n5JV4Cf+4y0KNXW48TLj5DwfXpvWlxXplU
 github.com/opencontainers/selinux v1.12.0/go.mod h1:BTPX+bjVbWGXw7ZZWUbdENt8w0htPSrlgOOysQaU62U=
 github.com/osbuild/blueprint v1.23.0 h1:HGMuRKpYg2xBy1QnAQDaIM6xnmzXh4QBrjic86C6Xr8=
 github.com/osbuild/blueprint v1.23.0/go.mod h1:HPlJzkEl7q5g8hzaGksUk7ifFAy9QFw9LmzhuFOAVm4=
-github.com/osbuild/images v0.238.0 h1:qJnMZOgtuoSJrXdSzyqDm+h5qw+cKK+oJIQFEG7W7LU=
-github.com/osbuild/images v0.238.0/go.mod h1:3/nKlYk9W8bsgrb8svP0j4q8/LlqY4F12eAqUgLLo5c=
+github.com/osbuild/images v0.240.0 h1:IbwfT1Vm43rgsM0C9M1MBY6Zs7W2SPuupzuL4E3OXpc=
+github.com/osbuild/images v0.240.0/go.mod h1:lr0fqJjjOCurTMbgMSDxTwnEalx6CkOVqyB0QmvNqO4=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=


### PR DESCRIPTION
```
Changes with 0.239.0

----------------
  - Support post quantum cryptography GPG keys (HMS-9985) (#2152)
    - Author: Sanne Raymaekers, Reviewers: Nobody
  - arch: add ARCH_ARM (#2168)
    - Author: Matija Tudan, Reviewers: Simon de Vlieger, Tomáš Hozza
  - test/scripts: upload image and manifest first then info.json (#2179)
    - Author: Achilleas Koutsou, Reviewers: Sanne Raymaekers, Tomáš Hozza

— Somewhere on the Internet, 2026-02-09

---

Changes with 0.240.0

----------------
  - Update snapshots to 20260211 (#2191)
    - Author: SchutzBot, Reviewers: Lukáš Zapletal, Simon de Vlieger
  - deps: update to Go 1.24 (#2192)
    - Author: Lukáš Zapletal, Reviewers: Brian C. Lane, Simon de Vlieger
  - depsolvednf: improve error reporting (#2156)
    - Author: Lukáš Zapletal, Reviewers: Brian C. Lane, Simon de Vlieger
  - pkg/bib/container: Support use in rootless containers (#2167)
    - Author: Alexander Larsson, Reviewers: Achilleas Koutsou, Simon de Vlieger
  - pkg/rpmmd: remove tags from modularity structures (#2187)
    - Author: Tomáš Hozza, Reviewers: Lukáš Zapletal, Simon de Vlieger

— Somewhere on the Internet, 2026-02-12
```