### PR TITLE
go.mod: update osbuild/images to v0.243.0

### DIFF
--- a/cmd/image-builder/main_test.go
+++ b/cmd/image-builder/main_test.go
@@ -310,7 +310,7 @@ func TestManifestIntegrationOstreeSmokeErrors(t *testing.T) {
 	baseArgs := []string{
 		"manifest",
 		"--arch=x86_64",
-		"--distro=fedora-43",
+		"--distro=centos-9",
 	}
 
 	for _, tc := range []struct {
@@ -318,12 +318,12 @@ func TestManifestIntegrationOstreeSmokeErrors(t *testing.T) {
 		expectedErr string
 	}{
 		{
-			[]string{"iot-raw-xz"},
-			`options validation failed for image type "iot-raw-xz": ostree.url: required`,
+			[]string{"edge-ami"},
+			`options validation failed for image type "edge-ami": ostree.url: required, there is no default available`,
 		},
 		{
-			[]string{"generic-qcow2", "--ostree-url=http://example.com/"},
-			`OSTree is not supported for "generic-qcow2"`,
+			[]string{"qcow2", "--ostree-url=http://example.com/"},
+			`OSTree is not supported for "qcow2"`,
 		},
 	} {
 		args := append(baseArgs, tc.extraArgs...)

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/gobwas/glob v0.2.3
 	github.com/mattn/go-isatty v0.0.20
 	github.com/osbuild/blueprint v1.23.0
-	github.com/osbuild/images v0.240.0
+	github.com/osbuild/images v0.244.0
 	github.com/sirupsen/logrus v1.9.4
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/pflag v1.0.10

--- a/go.sum
+++ b/go.sum
@@ -289,8 +289,8 @@ github.com/opencontainers/selinux v1.12.0 h1:6n5JV4Cf+4y0KNXW48TLj5DwfXpvWlxXplU
 github.com/opencontainers/selinux v1.12.0/go.mod h1:BTPX+bjVbWGXw7ZZWUbdENt8w0htPSrlgOOysQaU62U=
 github.com/osbuild/blueprint v1.23.0 h1:HGMuRKpYg2xBy1QnAQDaIM6xnmzXh4QBrjic86C6Xr8=
 github.com/osbuild/blueprint v1.23.0/go.mod h1:HPlJzkEl7q5g8hzaGksUk7ifFAy9QFw9LmzhuFOAVm4=
-github.com/osbuild/images v0.240.0 h1:IbwfT1Vm43rgsM0C9M1MBY6Zs7W2SPuupzuL4E3OXpc=
-github.com/osbuild/images v0.240.0/go.mod h1:lr0fqJjjOCurTMbgMSDxTwnEalx6CkOVqyB0QmvNqO4=
+github.com/osbuild/images v0.244.0 h1:rtV1kfynZI0MjUFciA339vQsSFWbEjTR+rSYebHU1T4=
+github.com/osbuild/images v0.244.0/go.mod h1:lr0fqJjjOCurTMbgMSDxTwnEalx6CkOVqyB0QmvNqO4=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=


### PR DESCRIPTION
tag v0.241.0
Tagger: imagebuilder-bot <imagebuilder-bots+imagebuilder-bot@redhat.com>

Changes with 0.241.0

----------------
  - Move bootc distro and image type code into generic distro (osbuild/images#2172)
    - Author: Achilleas Koutsou, Reviewers: Nobody
  - Use functions from Go 1.24 stdlib (osbuild/images#2194)
    - Author: Lukáš Zapletal, Reviewers: Achilleas Koutsou, Simon de Vlieger
  - distro: introduce ostree default URL (HMS-10152) (osbuild/images#2186)
    - Author: Simon de Vlieger, Reviewers: Lukáš Zapletal, Tomáš Hozza
  - distro: move ostree default reference to image type (HMS-10151) (osbuild/images#2184)
    - Author: Simon de Vlieger, Reviewers: Lukáš Zapletal, Tomáš Hozza

— Somewhere on the Internet, 2026-02-16

---

tag v0.242.0
Tagger: imagebuilder-bot <imagebuilder-bots+imagebuilder-bot@redhat.com>

Changes with 0.242.0

----------------
  - Cleanup remotefile resolver and delete internal/worker (osbuild/images#2178)
    - Author: Lukáš Zapletal, Reviewers: Achilleas Koutsou, Tomáš Hozza
  - Enable BSI OpenSCAP profile for RHEL 10.2 (HMS-9407) (osbuild/images#2199)
    - Author: Gianluca Zuccarelli, Reviewers: Achilleas Koutsou, Tomáš Hozza
  - New image type for RHEL 9 and 10: ec2-cvm [HMS-10096] (osbuild/images#2177)
    - Author: Achilleas Koutsou, Reviewers: Lukáš Zapletal, Tomáš Hozza
  - Update osbuild dependency commit ID (osbuild/images#2198)
    - Author: SchutzBot, Reviewers: Achilleas Koutsou, Tomáš Hozza
  - check-host-config: convert tests to tabular format (osbuild/images#2164)
    - Author: Lukáš Zapletal, Reviewers: Achilleas Koutsou, Tomáš Hozza
  - data/repositories: update f45 keys (osbuild/images#2181)
    - Author: Simon de Vlieger, Reviewers: Achilleas Koutsou, Lukáš Zapletal
  - distro: set ostree ref only on ostree types in test distro (osbuild/images#2201)
    - Author: Achilleas Koutsou, Reviewers: Brian C. Lane, Simon de Vlieger
  - fedora: atomic desktops installers and disk images (HMS-10174, HMS-10175) (osbuild/images#2188)
    - Author: Simon de Vlieger, Reviewers: Lukáš Zapletal, Tomáš Hozza
  - pkg/cloud/awscloud: allow specifying AWS credentials profile (osbuild/images#2157)
    - Author: Jakub Kadlčík, Reviewers: Lukáš Zapletal, Simon de Vlieger
  - rhel/centos-9: grow `/boot` for minimal-raw (osbuild/images#2200)
    - Author: Simon de Vlieger, Reviewers: Achilleas Koutsou, Lukáš Zapletal, Tomáš Hozza
  - test/scripts: don't use post-release version bump commits for osbuild (osbuild/images#2195)
    - Author: Achilleas Koutsou, Reviewers: Lukáš Zapletal, Simon de Vlieger, Tomáš Hozza

— Somewhere on the Internet, 2026-02-17

---

tag v0.243.0
Tagger: imagebuilder-bot <imagebuilder-bots+imagebuilder-bot@redhat.com>

Changes with 0.243.0

----------------
  - Move bootc pxe initrd creation into the Containerfile (osbuild/images#2202)
    - Author: Brian C. Lane, Reviewers: Achilleas Koutsou, Simon de Vlieger
  - distro: add erofs options into iso (osbuild/images#2196)
    - Author: Anna Vítová, Reviewers: Simon de Vlieger
  - fedora: atomic installer default config and erofs (HMS-10220) (osbuild/images#2209)
    - Author: Simon de Vlieger, Reviewers: Brian C. Lane, Lukáš Zapletal
  - many: copy ErofsOptions in manifest (osbuild/images#2212)
    - Author: Lukáš Zapletal, Reviewers: Simon de Vlieger, Tomáš Hozza
  - schutzbot: bump terraform hash (osbuild/images#2205)
    - Author: Simon de Vlieger, Reviewers: Anna Vítová, Lukáš Zapletal

— Somewhere on the Internet, 2026-02-19

---

tag v0.244.0
Tagger: imagebuilder-bot <imagebuilder-bots+imagebuilder-bot@redhat.com>

Changes with 0.244.0

----------------
  - pkg/osbuild/rpm: don't collect GPG keys from repos with CheckGPG=false (osbuild/images#2203)
    - Author: Tomáš Hozza, Reviewers: Achilleas Koutsou, Lukáš Zapletal

— Somewhere on the Internet, 2026-02-19

---