### PR TITLE
deps: bump images to 0.257.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/gobwas/glob v0.2.3
 	github.com/mattn/go-isatty v0.0.20
 	github.com/osbuild/blueprint v1.29.0
-	github.com/osbuild/images v0.256.0
+	github.com/osbuild/images v0.257.0
 	github.com/sirupsen/logrus v1.9.4
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/pflag v1.0.10

--- a/go.sum
+++ b/go.sum
@@ -289,8 +289,8 @@ github.com/opencontainers/selinux v1.12.0 h1:6n5JV4Cf+4y0KNXW48TLj5DwfXpvWlxXplU
 github.com/opencontainers/selinux v1.12.0/go.mod h1:BTPX+bjVbWGXw7ZZWUbdENt8w0htPSrlgOOysQaU62U=
 github.com/osbuild/blueprint v1.29.0 h1:ilXFgSgAg4nq8V0dCWK4hWg5umWckQJdu/cdtJpH4bY=
 github.com/osbuild/blueprint v1.29.0/go.mod h1:HPlJzkEl7q5g8hzaGksUk7ifFAy9QFw9LmzhuFOAVm4=
-github.com/osbuild/images v0.256.0 h1:k+T5APD6WFDdaQMqxumjrgtfYI2lbC/xdEVlevDVCDQ=
-github.com/osbuild/images v0.256.0/go.mod h1:TZBesu7gCjEPCilTXsqi0cjZxeD44a+cqYxnZ5eYGC8=
+github.com/osbuild/images v0.257.0 h1:AamqAVetrqwCbDcbjbovUJnFuf0NScvP+0d1IDOP0ss=
+github.com/osbuild/images v0.257.0/go.mod h1:TZBesu7gCjEPCilTXsqi0cjZxeD44a+cqYxnZ5eYGC8=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=


### PR DESCRIPTION
This changes atomic ISOs to use bare-user mode on the embedded ostree repositories which resolves a bug where the repositories were considered corrupt due to missing SELinix labeling.