### PR TITLE
image-builder.spec: fix version number in the spec file

### DIFF
--- a/image-builder.spec
+++ b/image-builder.spec
@@ -7,7 +7,7 @@
 
 %global goipath         github.com/osbuild/image-builder-cli
 
-Version:        56
+Version:        61
 
 %gometa
 


### PR DESCRIPTION
Due to misconfigured branch protection settings, the last github release action failed to push the version bump. This makes sure the next release has the correct version number.