### PR TITLE
docs: generate manpages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ __pycache__
 *.tar.bz2
 recording-*.cast.json
 /image-builder
+man

--- a/Makefile
+++ b/Makefile
@@ -109,9 +109,14 @@ build: $(BUILDDIR)/bin/  ## build the binary from source
 	    GOARCH="$$arch" go build -ldflags="-s -w" -o ./bin/bib-canary-"$$arch" ./cmd/cross-arch/; \
 	done
 
+.PHONY: man
+man: build $(BUILDDIR)/man/man1/  ## Generate man pages
+	$(BUILDDIR)/bin/image-builder doc $(BUILDDIR)/man/man1/
+
 .PHONY: clean
 clean:  ## Remove all built binaries
 	rm -rf $(BUILDDIR)/bin/
+	rm -rf $(BUILDDIR)/man/
 	rm -rf $(CURDIR)/rpmbuild
 	rm -rf $(CURDIR)/release_artifacts
 

--- a/cmd/image-builder/main.go
+++ b/cmd/image-builder/main.go
@@ -702,6 +702,7 @@ operating systems like Fedora, CentOS and RHEL with easy customizations support.
 	describeImgCmd.Flags().Bool("in-vm", false, `run container in a virtual machine`)
 
 	rootCmd.AddCommand(describeImgCmd)
+	addDocCmd(rootCmd)
 
 	verbose, err := rootCmd.PersistentFlags().GetBool("verbose")
 	if err != nil {

--- a/cmd/image-builder/manpages.go
+++ b/cmd/image-builder/manpages.go
@@ -1,0 +1,22 @@
+package main
+
+import (
+	"github.com/spf13/cobra"
+	"github.com/spf13/cobra/doc"
+)
+
+func addDocCmd(rootCmd *cobra.Command) {
+	docCmd := &cobra.Command{
+		Use:    "doc <output-dir>",
+		Short:  "Generate man pages for this command",
+		Hidden: true,
+		Args:   cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			header := &doc.GenManHeader{
+				Section: "1",
+			}
+			return doc.GenManTree(rootCmd, header, args[0])
+		},
+	}
+	rootCmd.AddCommand(docCmd)
+}

--- a/go.mod
+++ b/go.mod
@@ -63,6 +63,7 @@ require (
 	github.com/containers/ocicrypt v1.2.1 // indirect
 	github.com/containers/storage v1.59.1 // indirect
 	github.com/coreos/go-semver v0.3.1 // indirect
+	github.com/cpuguy83/go-md2man/v2 v2.0.7 // indirect
 	github.com/cyberphone/json-canonicalization v0.0.0-20241213102144-19d51d7fe467 // indirect
 	github.com/cyphar/filepath-securejoin v0.4.1 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
@@ -125,6 +126,7 @@ require (
 	github.com/proglottis/gpgme v0.1.4 // indirect
 	github.com/prometheus/client_golang v1.23.0 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
+	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 	github.com/secure-systems-lab/go-securesystemslib v0.9.0 // indirect
 	github.com/sigstore/fulcio v1.6.6 // indirect
 	github.com/sigstore/protobuf-specs v0.4.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -96,6 +96,8 @@ github.com/containers/storage v1.59.1/go.mod h1:KoAYHnAjP3/cTsRS+mmWZGkufSY2GACi
 github.com/coreos/go-semver v0.3.1 h1:yi21YpKnrx1gt5R+la8n5WgS0kCrsPp33dmEyHReZr4=
 github.com/coreos/go-semver v0.3.1/go.mod h1:irMmmIw/7yzSRPWryHsK7EYSg09caPQL03VsM8rvUec=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
+github.com/cpuguy83/go-md2man/v2 v2.0.7 h1:zbFlGlXEAKlwXpmvle3d8Oe3YnkKIK4xSRTd3sHPnBo=
+github.com/cpuguy83/go-md2man/v2 v2.0.7/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/cyberphone/json-canonicalization v0.0.0-20241213102144-19d51d7fe467 h1:uX1JmpONuD549D73r6cgnxyUu18Zb7yHAy5AYU0Pm4Q=
 github.com/cyberphone/json-canonicalization v0.0.0-20241213102144-19d51d7fe467/go.mod h1:uzvlm1mxhHkdfqitSA92i7Se+S9ksOn3a3qmv/kyOCw=
 github.com/cyphar/filepath-securejoin v0.4.1 h1:JyxxyPEaktOD+GAnqIqTf9A8tHyAG22rowi7HkoSU1s=
@@ -312,6 +314,7 @@ github.com/rivo/uniseg v0.4.7 h1:WUdvkW8uEhrYfLC4ZzdpI2ztxP1I582+49Oc5Mq64VQ=
 github.com/rivo/uniseg v0.4.7/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUcx88=
 github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=
 github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
+github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf35Ld67mk=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/santhosh-tekuri/jsonschema/v6 v6.0.2 h1:KRzFb2m7YtdldCEkzs6KqmJw4nqEVZGK7IN2kJkjTuQ=
 github.com/santhosh-tekuri/jsonschema/v6 v6.0.2/go.mod h1:JXeL+ps8p7/KNMjDQk3TCwPpBy0wYklyWTfbkIzdIFU=

--- a/image-builder.spec
+++ b/image-builder.spec
@@ -92,12 +92,18 @@ GOTAGS="exclude_graphdriver_btrfs"
 export LDFLAGS="${LDFLAGS} -X 'main.version=%{version}'"
 %gobuild ${GOTAGS:+-tags=$GOTAGS} -o %{gobuilddir}/bin/image-builder %{goipath}/cmd/image-builder
 
+# Generate man pages
+mkdir -p man/man1
+%{gobuilddir}/bin/image-builder doc man/man1/
+
 %install
 install -m 0755 -vd                                 %{buildroot}%{_bindir}
 install -m 0755 -vp %{gobuilddir}/bin/image-builder %{buildroot}%{_bindir}/
 # tmpfiles.d snippet
 install -m 0755 -vd                                 %{buildroot}%{_tmpfilesdir}
 install -m 0644 -vp data/tmpfiles.d/image-builder.conf %{buildroot}%{_tmpfilesdir}/image-builder.conf
+install -m 0755 -vd                                 %{buildroot}%{_mandir}/man1
+install -m 0644 -vp man/man1/image-builder*.1       %{buildroot}%{_mandir}/man1/
 %check
 export GOFLAGS="-buildmode=pie"
 %if 0%{?rhel}
@@ -115,6 +121,7 @@ cd $PWD/_build/src/%{goipath}
 %doc README.md
 %{_bindir}/image-builder
 %{_tmpfilesdir}/image-builder.conf
+%{_mandir}/man1/image-builder*.1*
 %ghost %attr(0755, root, root) %dir /var/cache/image-builder
 
 %changelog

--- a/image-builder.spec
+++ b/image-builder.spec
@@ -90,15 +90,15 @@ GOTAGS="exclude_graphdriver_btrfs"
 %endif
 
 export LDFLAGS="${LDFLAGS} -X 'main.version=%{version}'"
-%gobuild ${GOTAGS:+-tags=$GOTAGS} -o %{gobuilddir}/bin/image-builder %{goipath}/cmd/image-builder
+%gobuild ${GOTAGS:+-tags=$GOTAGS} -o _bin/image-builder %{goipath}/cmd/image-builder
 
 # Generate man pages
 mkdir -p man/man1
-%{gobuilddir}/bin/image-builder doc man/man1/
+_bin/image-builder doc man/man1/
 
 %install
 install -m 0755 -vd                                 %{buildroot}%{_bindir}
-install -m 0755 -vp %{gobuilddir}/bin/image-builder %{buildroot}%{_bindir}/
+install -m 0755 -vp _bin/image-builder              %{buildroot}%{_bindir}/
 # tmpfiles.d snippet
 install -m 0755 -vd                                 %{buildroot}%{_tmpfilesdir}
 install -m 0644 -vp data/tmpfiles.d/image-builder.conf %{buildroot}%{_tmpfilesdir}/image-builder.conf


### PR DESCRIPTION
Create manpages by using Cobra's built-in ability to do so. Add a hidden command that we call in our RPM specfile to generate the pages and install them in the appropriate location.

Also adds a new Makefile option to generate the manpages.

---

Looks like:

<img width="1072" height="854" alt="image" src="https://github.com/user-attachments/assets/6bce7356-24a2-4721-9df9-490273929ee4" />
<img width="1049" height="1322" alt="image" src="https://github.com/user-attachments/assets/3578f578-94d5-46da-a264-ee1947897c67" />

Etc.