### PR TITLE
main: `--version` -> `version` subcommand

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,6 +261,25 @@ $ image-builder list --format=json
 ]
 ```
 
+### Version information
+
+To show version information about the installed `image-builder`:
+```console
+$ image-builder version
+image-builder:
+  version: 0.5
+  commit: abc123
+  dependencies:
+    images: v0.100.0
+    osbuild: "105"
+```
+
+The output format can be changed with `--format`, supported formats are `yaml` (default) and `json`:
+```console
+$ image-builder version --format=json | jq '.["image-builder"].version'
+"0.5"
+```
+
 ## Modifying the set of used repositories
 
 There are various ways to add extra repositories or override the default

--- a/cmd/image-builder/main.go
+++ b/cmd/image-builder/main.go
@@ -60,6 +60,22 @@ func basenameFor(img *imagefilter.Result, userBasename string) string {
 	return fmt.Sprintf("%s-%s-%s", distro.Name(), img.ImgType.Name(), arch.Name())
 }
 
+func cmdVersion(cmd *cobra.Command, args []string) error {
+	format, err := cmd.Flags().GetString("format")
+	if err != nil {
+		return err
+	}
+	switch format {
+	case "", "yaml":
+		fmt.Fprint(cmd.OutOrStdout(), prettyVersion())
+	case "json":
+		fmt.Fprint(cmd.OutOrStdout(), jsonVersion())
+	default:
+		return fmt.Errorf("unsupported format %q, supported formats: yaml, json", format)
+	}
+	return nil
+}
+
 func cmdListImages(cmd *cobra.Command, args []string) error {
 	filter, err := cmd.Flags().GetStringArray("filter")
 	if err != nil {
@@ -576,7 +592,7 @@ operating systems like Fedora, CentOS and RHEL with easy customizations support.
 			// support lazy version strings and we need to call "osbuild" subprocess
 			// to get its version.
 			if versionFlag, err := cmd.Flags().GetBool("version"); err == nil && versionFlag {
-				fmt.Print(prettyVersion())
+				fmt.Fprint(cmd.OutOrStdout(), prettyVersion())
 			} else {
 				cmd.Help()
 			}
@@ -609,6 +625,15 @@ operating systems like Fedora, CentOS and RHEL with easy customizations support.
 	listCmd.Flags().StringArray("filter", nil, `Filter distributions by a specific criteria (e.g. "type:iot*")`)
 	listCmd.Flags().String("format", "", "Output in a specific format (text, json)")
 	rootCmd.AddCommand(listCmd)
+
+	versionCmd := &cobra.Command{
+		Use:   "version",
+		Short: "Print version information",
+		RunE:  cmdVersion,
+		Args:  cobra.NoArgs,
+	}
+	versionCmd.Flags().String("format", "", "Output in a specific format (yaml, json)")
+	rootCmd.AddCommand(versionCmd)
 
 	manifestCmd := &cobra.Command{
 		Use:          "manifest <image-type>",

--- a/cmd/image-builder/main.go
+++ b/cmd/image-builder/main.go
@@ -592,6 +592,7 @@ operating systems like Fedora, CentOS and RHEL with easy customizations support.
 			// support lazy version strings and we need to call "osbuild" subprocess
 			// to get its version.
 			if versionFlag, err := cmd.Flags().GetBool("version"); err == nil && versionFlag {
+				fmt.Fprintln(cmd.ErrOrStderr(), `Flag --version has been deprecated, use "image-builder version" instead`)
 				fmt.Fprint(cmd.OutOrStdout(), prettyVersion())
 			} else {
 				cmd.Help()
@@ -599,7 +600,8 @@ operating systems like Fedora, CentOS and RHEL with easy customizations support.
 		},
 	}
 
-	rootCmd.Flags().Bool("version", false, "Print version information and exit")
+	rootCmd.Flags().Bool("version", false, "Print version information and exit (deprecated: use \"image-builder version\" instead)")
+	rootCmd.Flags().MarkHidden("version")
 	var forceRepoDir string
 	rootCmd.PersistentFlags().StringVar(&forceRepoDir, "force-repo-dir", "", "Override the default repository search path for custom repository files")
 	rootCmd.PersistentFlags().StringVar(&forceRepoDir, "force-data-dir", "", `Override the default data directory for e.g. custom repositories/*.json data`)

--- a/cmd/image-builder/version.go
+++ b/cmd/image-builder/version.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 	"runtime/debug"
@@ -16,13 +17,13 @@ var version = "unknown"
 
 type versionDescription struct {
 	ImageBuilder struct {
-		Version      string `yaml:"version"`
-		Commit       string `yaml:"commit"`
+		Version      string `yaml:"version" json:"version"`
+		Commit       string `yaml:"commit" json:"commit"`
 		Dependencies struct {
-			Images  string `yaml:"images"`
-			OSBuild string `yaml:"osbuild"`
-		} `yaml:"dependencies"`
-	} `yaml:"image-builder"`
+			Images  string `yaml:"images" json:"images"`
+			OSBuild string `yaml:"osbuild" json:"osbuild"`
+		} `yaml:"dependencies" json:"dependencies"`
+	} `yaml:"image-builder" json:"image-builder"`
 }
 
 func readVersionInfo() *versionDescription {
@@ -69,4 +70,12 @@ func prettyVersion() string {
 	enc.Encode(readVersionInfo())
 
 	return b.String()
+}
+
+func jsonVersion() string {
+	b, err := json.MarshalIndent(readVersionInfo(), "", "  ")
+	if err != nil {
+		return fmt.Sprintf(`{"error": "%s"}`, err)
+	}
+	return string(b) + "\n"
 }

--- a/cmd/image-builder/version_test.go
+++ b/cmd/image-builder/version_test.go
@@ -11,12 +11,16 @@ import (
 	main "github.com/osbuild/image-builder-cli/cmd/image-builder"
 )
 
-func TestVersionFlag(t *testing.T) {
+func TestVersionFlagDeprecated(t *testing.T) {
 	restore := main.MockOsArgs([]string{"--version"})
 	defer restore()
 
 	var fakeStdout bytes.Buffer
 	restore = main.MockOsStdout(&fakeStdout)
+	defer restore()
+
+	var fakeStderr bytes.Buffer
+	restore = main.MockOsStderr(&fakeStderr)
 	defer restore()
 
 	err := main.Run()
@@ -27,6 +31,9 @@ func TestVersionFlag(t *testing.T) {
 	assert.Contains(t, output, "version:")
 	assert.Contains(t, output, "commit:")
 	assert.Contains(t, output, "dependencies:")
+	assert.NotContains(t, output, "deprecated")
+
+	assert.Contains(t, fakeStderr.String(), "deprecated")
 }
 
 func TestVersionSubcommandYAML(t *testing.T) {

--- a/cmd/image-builder/version_test.go
+++ b/cmd/image-builder/version_test.go
@@ -1,0 +1,95 @@
+package main_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	main "github.com/osbuild/image-builder-cli/cmd/image-builder"
+)
+
+func TestVersionFlag(t *testing.T) {
+	restore := main.MockOsArgs([]string{"--version"})
+	defer restore()
+
+	var fakeStdout bytes.Buffer
+	restore = main.MockOsStdout(&fakeStdout)
+	defer restore()
+
+	err := main.Run()
+	require.NoError(t, err)
+
+	output := fakeStdout.String()
+	assert.Contains(t, output, "image-builder:")
+	assert.Contains(t, output, "version:")
+	assert.Contains(t, output, "commit:")
+	assert.Contains(t, output, "dependencies:")
+}
+
+func TestVersionSubcommandYAML(t *testing.T) {
+	for _, args := range [][]string{
+		{"version"},
+		{"version", "--format=yaml"},
+	} {
+		t.Run(args[len(args)-1], func(t *testing.T) {
+			restore := main.MockOsArgs(args)
+			defer restore()
+
+			var fakeStdout bytes.Buffer
+			restore = main.MockOsStdout(&fakeStdout)
+			defer restore()
+
+			err := main.Run()
+			require.NoError(t, err)
+
+			output := fakeStdout.String()
+			assert.Contains(t, output, "image-builder:")
+			assert.Contains(t, output, "version:")
+			assert.Contains(t, output, "commit:")
+			assert.Contains(t, output, "dependencies:")
+		})
+	}
+}
+
+func TestVersionSubcommandJSON(t *testing.T) {
+	restore := main.MockOsArgs([]string{"version", "--format=json"})
+	defer restore()
+
+	var fakeStdout bytes.Buffer
+	restore = main.MockOsStdout(&fakeStdout)
+	defer restore()
+
+	err := main.Run()
+	require.NoError(t, err)
+
+	output := fakeStdout.String()
+
+	var parsed map[string]interface{}
+	err = json.Unmarshal([]byte(output), &parsed)
+	require.NoError(t, err, "output must be valid JSON")
+
+	ib, ok := parsed["image-builder"].(map[string]interface{})
+	require.True(t, ok, "must have image-builder key")
+	assert.Contains(t, ib, "version")
+	assert.Contains(t, ib, "commit")
+
+	deps, ok := ib["dependencies"].(map[string]interface{})
+	require.True(t, ok, "must have dependencies key")
+	assert.Contains(t, deps, "images")
+	assert.Contains(t, deps, "osbuild")
+}
+
+func TestVersionSubcommandUnsupportedFormat(t *testing.T) {
+	restore := main.MockOsArgs([]string{"version", "--format=xml"})
+	defer restore()
+
+	var fakeStdout bytes.Buffer
+	restore = main.MockOsStdout(&fakeStdout)
+	defer restore()
+
+	err := main.Run()
+	require.EqualError(t, err, `unsupported format "xml", supported formats: yaml, json`)
+}

--- a/doc/01-usage.md
+++ b/doc/01-usage.md
@@ -341,6 +341,36 @@ $ image-builder manifest --arch aarch64 minimal-raw-xz
 # ... output ...
 ```
 
+## `image-builder version`
+
+The `version` command prints version information about the `image-builder` binary including its dependencies.
+
+```console
+$ image-builder version
+image-builder:
+  version: 0.5
+  commit: abc123
+  dependencies:
+    images: v0.100.0
+    osbuild: "105"
+```
+
+The output format can be changed with `--format`. Available formats are `yaml` (default) and `json`:
+
+```console
+$ image-builder version --format=json
+{
+  "image-builder": {
+    "version": "0.5",
+    "commit": "abc123",
+    "dependencies": {
+      "images": "v0.100.0",
+      "osbuild": "105"
+    }
+  }
+}
+```
+
 ## Blueprints
 
 Images can be customized with [blueprints](https://osbuild.org/docs/user-guide/blueprint-reference). For example we could build the `qcow2` we built above with some customizations applied.


### PR DESCRIPTION
Deprecate the `--version` subcommand because it mixes badly with wanting to pick an output format for it (it'd be easier to read JSON from our `koji-image-builder` plugin in the future).

Instead deprecate the old argument and introduce a new `version` subcommand with pickable output formats. Docs and tests included.