### PR TITLE
cmd: drop "bootc is experimental"

### DIFF
--- a/cmd/image-builder/main.go
+++ b/cmd/image-builder/main.go
@@ -270,12 +270,6 @@ func cmdManifestWrapper(pbar progress.ProgressBar, cmd *cobra.Command, args []st
 	if err != nil {
 		return nil, err
 	}
-	// XXX: remove once https://github.com/osbuild/images/pull/1797
-	// and https://github.com/osbuild/bootc-image-builder/pull/1014
-	// are merged
-	if bootcRef != "" {
-		fmt.Fprintln(os.Stderr, "WARNING: bootc support is experimental")
-	}
 
 	// no error check here as this is (deliberately) not defined on
 	// "manifest" (if "images" learn to set the output filename in

--- a/doc/01-usage.md
+++ b/doc/01-usage.md
@@ -198,7 +198,6 @@ When this happens you'll be presented with an error:
 
 ```console
 $ sudo image-builder build --bootc-ref quay.io/fedora/fedora-bootc:rawhide qcow2
-WARNING: bootc support is experimental
 [|] Manifest generation step
 Message: Building manifest for bootc-based-qcow2
 error: no default fs set: mount "/boot" requires a filesystem but none set


### PR DESCRIPTION
This is a left over that we should no longer be showing. Both PRs have been merged and it's especially confusing now that we're publically stating our timelines and asking users to migrate.

---

Mentioned by Niklas Reisser in https://github.com/osbuild/bootc-image-builder/issues/1221