### PR TITLE
deps: bump images to 0.266.0

### DIFF
--- a/.github/workflows/check-spec.yaml
+++ b/.github/workflows/check-spec.yaml
@@ -27,8 +27,9 @@ jobs:
         run: |
           # we have the same build-deps as the images library
           curl -sL https://raw.githubusercontent.com/osbuild/images/refs/heads/main/pyproject.toml > pyproject.toml
-          curl -sL https://raw.githubusercontent.com/osbuild/images/refs/heads/main/test/scripts/install-dependencies | bash
-
+          mkdir -p test/scripts
+          curl -sL https://raw.githubusercontent.com/osbuild/images/refs/heads/main/test/scripts/install-dependencies > test/scripts/install-dependencies
+          bash test/scripts/install-dependencies
       - name: Vendor dependencies
         run: go mod vendor
 

--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -34,7 +34,9 @@ jobs:
         run: |
           # we have the same build-deps as the images library
           curl -sL https://raw.githubusercontent.com/osbuild/images/refs/heads/main/pyproject.toml > pyproject.toml
-          curl -sL https://raw.githubusercontent.com/osbuild/images/refs/heads/main/test/scripts/install-dependencies | bash
+          mkdir -p test/scripts
+          curl -sL https://raw.githubusercontent.com/osbuild/images/refs/heads/main/test/scripts/install-dependencies > test/scripts/install-dependencies
+          bash test/scripts/install-dependencies
           # we also need createrepo_c
           dnf install -y createrepo_c
       - name: Check osbuild version

--- a/Schutzfile
+++ b/Schutzfile
@@ -2,7 +2,7 @@
   "common": {
     "dependencies": {
       "osbuild": {
-        "commit": "eb2d3de47cebc09d5bc68e215f14efa0e5941594"
+        "commit": "f312d0acb2022212b825e236e417499648ff4dab"
       }
     }
   }

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/gobwas/glob v0.2.3
 	github.com/mattn/go-isatty v0.0.22
 	github.com/osbuild/blueprint v1.30.0
-	github.com/osbuild/images v0.263.0
+	github.com/osbuild/images v0.266.0
 	github.com/sirupsen/logrus v1.9.4
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/pflag v1.0.10

--- a/go.sum
+++ b/go.sum
@@ -291,8 +291,8 @@ github.com/opencontainers/selinux v1.12.0 h1:6n5JV4Cf+4y0KNXW48TLj5DwfXpvWlxXplU
 github.com/opencontainers/selinux v1.12.0/go.mod h1:BTPX+bjVbWGXw7ZZWUbdENt8w0htPSrlgOOysQaU62U=
 github.com/osbuild/blueprint v1.30.0 h1:p8BpF4H5dJtvGCcvDaoyTzEdNVgVoJNh985ZyFKnJtk=
 github.com/osbuild/blueprint v1.30.0/go.mod h1:HPlJzkEl7q5g8hzaGksUk7ifFAy9QFw9LmzhuFOAVm4=
-github.com/osbuild/images v0.263.0 h1:i0snpZocSwXP60oa/PSVp47QkTfFEEdcoxdN4BcLBww=
-github.com/osbuild/images v0.263.0/go.mod h1:KbIq93dxz8WASGXEx1Mp2L1OjlpBKLru3UFSNvhAMYM=
+github.com/osbuild/images v0.266.0 h1:DDk7IlN2sNnGFK5HpC34G2EKJ0Or5KXFR4rJAGfER9c=
+github.com/osbuild/images v0.266.0/go.mod h1:KbIq93dxz8WASGXEx1Mp2L1OjlpBKLru3UFSNvhAMYM=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=

--- a/image-builder.spec
+++ b/image-builder.spec
@@ -3,7 +3,7 @@
 # required. So if this needs backport to places where there is no
 # recent osbuild available we could simply make --use-librepo false
 # and go back to 129.
-%global min_osbuild_version 178
+%global min_osbuild_version 181
 
 %global goipath         github.com/osbuild/image-builder-cli
 


### PR DESCRIPTION
This includes the addition of the initial built-in Fedora ELN definitions for [1] and the initial support for sealed bootable containers for [2].

[1]: https://github.com/fedora-eln/eln/issues/502
[2]: https://github.com/osbuild/image-builder/issues/2427