### PR TITLE
test: switch to Fedora 44

### DIFF
--- a/test/bib/test_build_iso.py
+++ b/test/bib/test_build_iso.py
@@ -95,7 +95,7 @@ def test_iso_install_img_is_squashfs(tmp_path, image_type):
 @pytest.mark.skipif(platform.system() != "Linux", reason="boot test only runs on linux right now")
 @pytest.mark.parametrize("container_ref", [
     "quay.io/centos-bootc/centos-bootc:stream10",
-    "quay.io/fedora/fedora-bootc:42",
+    "quay.io/fedora/fedora-bootc:44",
     "quay.io/centos-bootc/centos-bootc:stream9",
 ])
 # pylint: disable=too-many-locals

--- a/test/test_manifest.py
+++ b/test/test_manifest.py
@@ -186,7 +186,7 @@ def test_manifest_honors_rpmmd_cache(tmp_path, build_container):
 
 
 @pytest.mark.parametrize("bootc_ref,defaultfs", [
-    ("quay.io/fedora/fedora-bootc:42", "ext4"),
+    ("quay.io/fedora/fedora-bootc:44", "ext4"),
     ("quay.io/centos-bootc/centos-bootc:stream10", ""),
     ("quay.io/centos-bootc/centos-bootc:stream9", ""),
 ])

--- a/test/test_smoke.py
+++ b/test/test_smoke.py
@@ -63,7 +63,7 @@ def test_smoke_has_expected_images_fedora(build_container):
         "iot-simplified-installer": ["x86_64", "aarch64"],
     }
 
-    for distro in ["fedora-42", "fedora-43", "fedora-44"]:
+    for distro in ["fedora-43", "fedora-44", "fedora-45"]:
         for type_, arches in type_arch.items():
             for arch in arches:
                 assert f"{distro} type:{type_} arch:{arch}" in output


### PR DESCRIPTION
Remove all mentions of Fedora 42 in our tests and move to Fedora 44 where applicable.

I noticed in some PRs that tests based on Fedora 42 started failing, they pass on 44 and 42 is EOL now-ish.