### PR TITLE
main: `bootc inspect`

### DIFF
--- a/cmd/image-builder/bootc_test.go
+++ b/cmd/image-builder/bootc_test.go
@@ -1,0 +1,141 @@
+package main_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	main "github.com/osbuild/image-builder-cli/cmd/image-builder"
+	"github.com/osbuild/images/pkg/bootc"
+)
+
+func mockBootcInfo() *bootc.Info {
+	return &bootc.Info{
+		Imgref:  "quay.io/test/bootc:latest",
+		ImageID: "sha256:abc123",
+		Arch:    "x86_64",
+	}
+}
+
+func TestBootcInspectDefaultYAML(t *testing.T) {
+	restore := main.MockBootcResolveInfo(func(ref string) (*bootc.Info, error) {
+		assert.Equal(t, "quay.io/test/bootc:latest", ref)
+		return mockBootcInfo(), nil
+	})
+	defer restore()
+
+	restore = main.MockOsArgs([]string{"bootc", "inspect", "--ref=quay.io/test/bootc:latest"})
+	defer restore()
+
+	var fakeStdout bytes.Buffer
+	restore = main.MockOsStdout(&fakeStdout)
+	defer restore()
+
+	err := main.Run()
+	require.NoError(t, err)
+
+	output := fakeStdout.String()
+	assert.Contains(t, output, "imgref: quay.io/test/bootc:latest")
+	assert.Contains(t, output, "imageid: sha256:abc123")
+	assert.Contains(t, output, "arch: x86_64")
+}
+
+func TestBootcInspectExplicitYAML(t *testing.T) {
+	restore := main.MockBootcResolveInfo(func(ref string) (*bootc.Info, error) {
+		return mockBootcInfo(), nil
+	})
+	defer restore()
+
+	restore = main.MockOsArgs([]string{"bootc", "inspect", "--ref=quay.io/test/bootc:latest", "--format=yaml"})
+	defer restore()
+
+	var fakeStdout bytes.Buffer
+	restore = main.MockOsStdout(&fakeStdout)
+	defer restore()
+
+	err := main.Run()
+	require.NoError(t, err)
+
+	output := fakeStdout.String()
+	assert.Contains(t, output, "imgref: quay.io/test/bootc:latest")
+}
+
+func TestBootcInspectJSON(t *testing.T) {
+	restore := main.MockBootcResolveInfo(func(ref string) (*bootc.Info, error) {
+		return mockBootcInfo(), nil
+	})
+	defer restore()
+
+	restore = main.MockOsArgs([]string{"bootc", "inspect", "--ref=quay.io/test/bootc:latest", "--format=json"})
+	defer restore()
+
+	var fakeStdout bytes.Buffer
+	restore = main.MockOsStdout(&fakeStdout)
+	defer restore()
+
+	err := main.Run()
+	require.NoError(t, err)
+
+	var parsed map[string]interface{}
+	err = json.Unmarshal(fakeStdout.Bytes(), &parsed)
+	require.NoError(t, err, "output must be valid JSON")
+	assert.Equal(t, "quay.io/test/bootc:latest", parsed["Imgref"])
+	assert.Equal(t, "sha256:abc123", parsed["ImageID"])
+	assert.Equal(t, "x86_64", parsed["Arch"])
+}
+
+func TestBootcInspectUnsupportedFormat(t *testing.T) {
+	restore := main.MockBootcResolveInfo(func(ref string) (*bootc.Info, error) {
+		return mockBootcInfo(), nil
+	})
+	defer restore()
+
+	restore = main.MockOsArgs([]string{"bootc", "inspect", "--ref=quay.io/test/bootc:latest", "--format=xml"})
+	defer restore()
+
+	var fakeStdout bytes.Buffer
+	restore = main.MockOsStdout(&fakeStdout)
+	defer restore()
+
+	err := main.Run()
+	require.EqualError(t, err, `unsupported format "xml", supported formats: yaml, json`)
+}
+
+func TestBootcInspectResolveError(t *testing.T) {
+	restore := main.MockBootcResolveInfo(func(ref string) (*bootc.Info, error) {
+		return nil, fmt.Errorf("cannot resolve %q", ref)
+	})
+	defer restore()
+
+	restore = main.MockOsArgs([]string{"bootc", "inspect", "--ref=quay.io/bad/ref:latest"})
+	defer restore()
+
+	var fakeStdout bytes.Buffer
+	restore = main.MockOsStdout(&fakeStdout)
+	defer restore()
+
+	err := main.Run()
+	require.EqualError(t, err, `cannot resolve "quay.io/bad/ref:latest"`)
+}
+
+func TestBootcInspectMissingRef(t *testing.T) {
+	restore := main.MockBootcResolveInfo(func(ref string) (*bootc.Info, error) {
+		return mockBootcInfo(), nil
+	})
+	defer restore()
+
+	restore = main.MockOsArgs([]string{"bootc", "inspect"})
+	defer restore()
+
+	var fakeStdout bytes.Buffer
+	restore = main.MockOsStdout(&fakeStdout)
+	defer restore()
+
+	err := main.Run()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "ref")
+}

--- a/cmd/image-builder/export_test.go
+++ b/cmd/image-builder/export_test.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"os"
 
+	"github.com/osbuild/images/pkg/bootc"
 	"github.com/osbuild/images/pkg/cloud"
 	"github.com/osbuild/images/pkg/cloud/awscloud"
 	"github.com/osbuild/images/pkg/manifestgen"
@@ -74,6 +75,14 @@ func MockAwscloudNewUploader(f func(string, string, string, *awscloud.UploaderOp
 	awscloudNewUploader = f
 	return func() {
 		awscloudNewUploader = saved
+	}
+}
+
+func MockBootcResolveInfo(f func(string) (*bootc.Info, error)) (restore func()) {
+	saved := bootcResolveInfo
+	bootcResolveInfo = f
+	return func() {
+		bootcResolveInfo = saved
 	}
 }
 

--- a/cmd/image-builder/main.go
+++ b/cmd/image-builder/main.go
@@ -17,6 +17,8 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 
+	"go.yaml.in/yaml/v3"
+
 	"github.com/osbuild/image-builder-cli/pkg/progress"
 	"github.com/osbuild/images/pkg/arch"
 	"github.com/osbuild/images/pkg/bootc"
@@ -34,8 +36,9 @@ import (
 )
 
 var (
-	osStdout io.Writer = os.Stdout
-	osStderr io.Writer = os.Stderr
+	osStdout         io.Writer = os.Stdout
+	osStderr         io.Writer = os.Stderr
+	bootcResolveInfo           = bootc.ResolveBootcInfo
 )
 
 // cacheDirForUid returns the cache directory for the given uid.
@@ -99,6 +102,45 @@ func cmdVersion(cmd *cobra.Command, args []string) error {
 	}
 	return nil
 }
+
+func cmdBootcInspect(cmd *cobra.Command, args []string) error {
+	ref, err := cmd.Flags().GetString("ref")
+	if err != nil {
+		return err
+	}
+
+	info, err := bootcResolveInfo(ref)
+	if err != nil {
+		return err
+	}
+
+	format, err := cmd.Flags().GetString("format")
+	if err != nil {
+		return err
+	}
+
+	switch format {
+	case "", "yaml":
+		output, err := yaml.Marshal(&info)
+		if err != nil {
+			return err
+		}
+
+		fmt.Fprint(cmd.OutOrStdout(), string(output))
+	case "json":
+		output, err := json.Marshal(&info)
+		if err != nil {
+			return err
+		}
+
+		fmt.Fprint(cmd.OutOrStdout(), string(output))
+	default:
+		return fmt.Errorf("unsupported format %q, supported formats: yaml, json", format)
+	}
+
+	return nil
+}
+
 
 func cmdListImages(cmd *cobra.Command, args []string) error {
 	filter, err := cmd.Flags().GetStringArray("filter")
@@ -640,6 +682,25 @@ operating systems like Fedora, CentOS and RHEL with easy customizations support.
 
 	rootCmd.SetOut(osStdout)
 	rootCmd.SetErr(osStderr)
+
+	bootcCommand := &cobra.Command{
+		Use:	"bootc",
+		Short:  "bootc-related commands",
+		Args:   cobra.NoArgs,
+	}
+
+	bootcInspectCommand := &cobra.Command{
+		Use:	"inspect",
+		Short:  "Show data gathered by `image-builder` for a container",
+		RunE:   cmdBootcInspect,
+		Args:   cobra.NoArgs,
+	}
+	bootcInspectCommand.Flags().String("ref", "", `bootc container ref`)
+	_ = bootcInspectCommand.MarkFlagRequired("ref")
+	bootcInspectCommand.Flags().String("format", "", "Output in a specific format (yaml, json)")
+	bootcCommand.AddCommand(bootcInspectCommand)
+
+	rootCmd.AddCommand(bootcCommand)
 
 	listCmd := &cobra.Command{
 		Use:          "list",

--- a/doc/01-usage.md
+++ b/doc/01-usage.md
@@ -304,6 +304,32 @@ $ image-builder manifest --arch aarch64 minimal-raw-xz
 # ... output ...
 ```
 
+## `image-builder bootc`
+
+The `bootc` subcommand groups helpers for working with bootable containers.
+
+### `inspect`
+
+The `bootc inspect` command shows the data that `image-builder` gathers from a bootable container. This is useful for debugging and understanding how `image-builder` interprets a container before building an image from it.
+
+> [!WARNING]
+> *The inspect subcommand exposes internal information. We do not consider this format to be stable though we might stabilize with a public interface in the future.*
+
+The `--ref` flag is required and specifies the container reference to inspect. The container must be available in the container storage of the user running the command.
+
+```console
+$ sudo podman pull quay.io/centos-bootc/centos:stream10
+$ image-builder bootc inspect --ref quay.io/centos-bootc/centos:stream10
+# ... yaml output ...
+```
+
+The output format can be changed with `--format`. Available formats are `yaml` (default) and `json`:
+
+```console
+$ image-builder bootc inspect --ref quay.io/centos-bootc/centos:stream10 --format=json
+# ... json output ...
+```
+
 ## `image-builder version`
 
 The `version` command prints version information about the `image-builder` binary including its dependencies.


### PR DESCRIPTION
Introduce a new `bootc` subcommand where we can grow various helpers for working with bootable containers.

The first one of these is the `inspect` subcommand, this allows a user to dump the struct we get from `images` to determine what `image-builder` thinks about the container.

Usage as follows:

```
€ sudo ./image-builder bootc inspect --format json --ref localhost/fedora-kinoite-iso:44 | jq .OSInfo.KernelInfo
{
  "Version": "7.0.10-200.fc44.x86_64",
  "HasAbootImg": false
}
```

---

As said in the documentation this is an internal structure but it's still useful. Perhaps in the future we can standardize it.

The intent is also to have an umbrella to add additional `bootc` subcommands to with us /eventually/ migrating away from `--bootc-*` arguments on `build` to having them on `bootc convert` though that's a very big IF/MAYBE/PERHAPS.