### PR TITLE
main: `system` subcommand

### DIFF
--- a/cmd/image-builder/export_test.go
+++ b/cmd/image-builder/export_test.go
@@ -86,6 +86,22 @@ func MockBootcResolveInfo(f func(string) (*bootc.Info, error)) (restore func()) 
 	}
 }
 
+func MockGetCacheDir(f func() string) (restore func()) {
+	saved := getCacheDir
+	getCacheDir = f
+	return func() {
+		getCacheDir = saved
+	}
+}
+
+func MockDirSize(f func(string) (int64, error)) (restore func()) {
+	saved := dirSize
+	dirSize = f
+	return func() {
+		dirSize = saved
+	}
+}
+
 func MockManifestgenDepsolver(new manifestgen.DepsolveFunc) (restore func()) {
 	saved := manifestgenDepsolver
 	manifestgenDepsolver = new

--- a/cmd/image-builder/main.go
+++ b/cmd/image-builder/main.go
@@ -87,6 +87,22 @@ func basenameFor(img *imagefilter.Result, userBasename string) string {
 	return fmt.Sprintf("%s-%s-%s", distro.Name(), img.ImgType.Name(), arch.Name())
 }
 
+func cmdSystem(cmd *cobra.Command, args []string) error {
+	format, err := cmd.Flags().GetString("format")
+	if err != nil {
+		return err
+	}
+	switch format {
+	case "", "yaml":
+		fmt.Fprint(cmd.OutOrStdout(), prettySystemStatus())
+	case "json":
+		fmt.Fprint(cmd.OutOrStdout(), jsonSystemStatus())
+	default:
+		return fmt.Errorf("unsupported format %q, supported formats: yaml, json", format)
+	}
+	return nil
+}
+
 func cmdVersion(cmd *cobra.Command, args []string) error {
 	format, err := cmd.Flags().GetString("format")
 	if err != nil {
@@ -737,6 +753,15 @@ operating systems like Fedora, CentOS and RHEL with easy customizations support.
 	}
 	versionCmd.Flags().String("format", "", "Output in a specific format (yaml, json)")
 	rootCmd.AddCommand(versionCmd)
+
+	systemCmd := &cobra.Command{
+		Use:   "system",
+		Short: "Show system status information",
+		RunE:  cmdSystem,
+		Args:  cobra.NoArgs,
+	}
+	systemCmd.Flags().String("format", "", "Output in a specific format (yaml, json)")
+	rootCmd.AddCommand(systemCmd)
 
 	manifestCmd := &cobra.Command{
 		Use:          "manifest <image-type>",

--- a/cmd/image-builder/system.go
+++ b/cmd/image-builder/system.go
@@ -3,22 +3,92 @@ package main
 import (
 	"encoding/json"
 	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strconv"
 	"strings"
 
 	"go.yaml.in/yaml/v3"
 )
 
+type cacheMaxSize struct {
+	set   bool
+	value int64
+}
+
+func (c cacheMaxSize) MarshalJSON() ([]byte, error) {
+	if !c.set {
+		return json.Marshal("unknown")
+	}
+	if c.value == 0 {
+		return json.Marshal("unlimited")
+	}
+	return json.Marshal(c.value)
+}
+
+func (c cacheMaxSize) MarshalYAML() (interface{}, error) {
+	if !c.set {
+		return "unknown", nil
+	}
+	if c.value == 0 {
+		return "unlimited", nil
+	}
+	return c.value, nil
+}
+
 type systemStatus struct {
 	System struct {
 		Cache struct {
-			Path string `yaml:"path" json:"path"`
+			Path    string       `yaml:"path" json:"path"`
+			Size    int64        `yaml:"size" json:"size"`
+			MaxSize cacheMaxSize `yaml:"max-size" json:"max-size"`
 		} `yaml:"cache" json:"cache"`
 	} `yaml:"system" json:"system"`
 }
 
+var dirSize = calcDirSize
+var getCacheDir = defaultCacheDir
+
+func calcDirSize(path string) (int64, error) {
+	var total int64
+	err := filepath.WalkDir(path, func(_ string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if !d.IsDir() {
+			info, err := d.Info()
+			if err != nil {
+				return err
+			}
+			total += info.Size()
+		}
+		return nil
+	})
+	return total, err
+}
+
+func readCacheMaxSize(cacheDir string) cacheMaxSize {
+	data, err := os.ReadFile(filepath.Join(cacheDir, "cache.size"))
+	if err != nil {
+		return cacheMaxSize{}
+	}
+	n, err := strconv.ParseInt(strings.TrimSpace(string(data)), 10, 64)
+	if err != nil {
+		return cacheMaxSize{}
+	}
+	return cacheMaxSize{set: true, value: n}
+}
+
 func readSystemStatus() *systemStatus {
 	ss := &systemStatus{}
-	ss.System.Cache.Path = defaultCacheDir()
+	ss.System.Cache.Path = getCacheDir()
+	ss.System.Cache.MaxSize = readCacheMaxSize(ss.System.Cache.Path)
+	size, err := dirSize(ss.System.Cache.Path)
+	if err != nil && !os.IsNotExist(err) {
+		fmt.Fprintf(os.Stderr, "failed to calculate cache size: %v\n", err)
+	}
+	ss.System.Cache.Size = size
 	return ss
 }
 

--- a/cmd/image-builder/system.go
+++ b/cmd/image-builder/system.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"go.yaml.in/yaml/v3"
+)
+
+type systemStatus struct {
+	System struct {
+		Cache struct {
+			Path string `yaml:"path" json:"path"`
+		} `yaml:"cache" json:"cache"`
+	} `yaml:"system" json:"system"`
+}
+
+func readSystemStatus() *systemStatus {
+	ss := &systemStatus{}
+	ss.System.Cache.Path = defaultCacheDir()
+	return ss
+}
+
+func prettySystemStatus() string {
+	var b strings.Builder
+
+	enc := yaml.NewEncoder(&b)
+	enc.SetIndent(2)
+
+	enc.Encode(readSystemStatus())
+
+	return b.String()
+}
+
+func jsonSystemStatus() string {
+	b, err := json.MarshalIndent(readSystemStatus(), "", "  ")
+	if err != nil {
+		return fmt.Sprintf(`{"error": "%s"}`, err)
+	}
+	return string(b) + "\n"
+}

--- a/cmd/image-builder/system_test.go
+++ b/cmd/image-builder/system_test.go
@@ -1,0 +1,98 @@
+package main_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	main "github.com/osbuild/image-builder-cli/cmd/image-builder"
+)
+
+func TestSystemSubcommandYAML(t *testing.T) {
+	for _, args := range [][]string{
+		{"system"},
+		{"system", "--format=yaml"},
+	} {
+		t.Run(args[len(args)-1], func(t *testing.T) {
+			restore := main.MockOsArgs(args)
+			defer restore()
+
+			var fakeStdout bytes.Buffer
+			restore = main.MockOsStdout(&fakeStdout)
+			defer restore()
+
+			err := main.Run()
+			require.NoError(t, err)
+
+			output := fakeStdout.String()
+			assert.Contains(t, output, "system:")
+			assert.Contains(t, output, "cache:")
+			assert.Contains(t, output, "path:")
+		})
+	}
+}
+
+func TestSystemSubcommandJSON(t *testing.T) {
+	restore := main.MockOsArgs([]string{"system", "--format=json"})
+	defer restore()
+
+	var fakeStdout bytes.Buffer
+	restore = main.MockOsStdout(&fakeStdout)
+	defer restore()
+
+	err := main.Run()
+	require.NoError(t, err)
+
+	output := fakeStdout.String()
+
+	var parsed map[string]interface{}
+	err = json.Unmarshal([]byte(output), &parsed)
+	require.NoError(t, err, "output must be valid JSON")
+
+	sys, ok := parsed["system"].(map[string]interface{})
+	require.True(t, ok, "must have system key")
+	cache, ok := sys["cache"].(map[string]interface{})
+	require.True(t, ok, "must have cache key")
+	assert.Contains(t, cache, "path")
+	assert.NotEmpty(t, cache["path"])
+}
+
+func TestSystemSubcommandUnsupportedFormat(t *testing.T) {
+	restore := main.MockOsArgs([]string{"system", "--format=xml"})
+	defer restore()
+
+	var fakeStdout bytes.Buffer
+	restore = main.MockOsStdout(&fakeStdout)
+	defer restore()
+
+	err := main.Run()
+	require.EqualError(t, err, `unsupported format "xml", supported formats: yaml, json`)
+}
+
+func TestSystemSubcommandCachePathMatchesDefault(t *testing.T) {
+	restore := main.MockOsArgs([]string{"system", "--format=json"})
+	defer restore()
+
+	var fakeStdout bytes.Buffer
+	restore = main.MockOsStdout(&fakeStdout)
+	defer restore()
+
+	err := main.Run()
+	require.NoError(t, err)
+
+	var parsed struct {
+		System struct {
+			Cache struct {
+				Path string `json:"path"`
+			} `json:"cache"`
+		} `json:"system"`
+	}
+	err = json.Unmarshal(fakeStdout.Bytes(), &parsed)
+	require.NoError(t, err)
+
+	assert.Equal(t, main.CacheDirForUid(0), "/var/cache/image-builder/store")
+	assert.NotEmpty(t, parsed.System.Cache.Path)
+}

--- a/cmd/image-builder/system_test.go
+++ b/cmd/image-builder/system_test.go
@@ -3,6 +3,8 @@ package main_test
 import (
 	"bytes"
 	"encoding/json"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -11,7 +13,39 @@ import (
 	main "github.com/osbuild/image-builder-cli/cmd/image-builder"
 )
 
+func runSystemRaw(t *testing.T) map[string]interface{} {
+	t.Helper()
+	restore := main.MockOsArgs([]string{"system", "--format=json"})
+	defer restore()
+
+	var fakeStdout bytes.Buffer
+	restore = main.MockOsStdout(&fakeStdout)
+	defer restore()
+
+	err := main.Run()
+	require.NoError(t, err)
+
+	var parsed map[string]interface{}
+	err = json.Unmarshal(fakeStdout.Bytes(), &parsed)
+	require.NoError(t, err)
+	return parsed
+}
+
+func cacheFromRaw(t *testing.T, raw map[string]interface{}) map[string]interface{} {
+	t.Helper()
+	sys, ok := raw["system"].(map[string]interface{})
+	require.True(t, ok)
+	cache, ok := sys["cache"].(map[string]interface{})
+	require.True(t, ok)
+	return cache
+}
+
 func TestSystemSubcommandYAML(t *testing.T) {
+	restore := main.MockDirSize(func(string) (int64, error) {
+		return 4096, nil
+	})
+	defer restore()
+
 	for _, args := range [][]string{
 		{"system"},
 		{"system", "--format=yaml"},
@@ -31,33 +65,23 @@ func TestSystemSubcommandYAML(t *testing.T) {
 			assert.Contains(t, output, "system:")
 			assert.Contains(t, output, "cache:")
 			assert.Contains(t, output, "path:")
+			assert.Contains(t, output, "size:")
+			assert.Contains(t, output, "max-size:")
 		})
 	}
 }
 
 func TestSystemSubcommandJSON(t *testing.T) {
-	restore := main.MockOsArgs([]string{"system", "--format=json"})
+	restore := main.MockDirSize(func(string) (int64, error) {
+		return 12345, nil
+	})
 	defer restore()
 
-	var fakeStdout bytes.Buffer
-	restore = main.MockOsStdout(&fakeStdout)
-	defer restore()
-
-	err := main.Run()
-	require.NoError(t, err)
-
-	output := fakeStdout.String()
-
-	var parsed map[string]interface{}
-	err = json.Unmarshal([]byte(output), &parsed)
-	require.NoError(t, err, "output must be valid JSON")
-
-	sys, ok := parsed["system"].(map[string]interface{})
-	require.True(t, ok, "must have system key")
-	cache, ok := sys["cache"].(map[string]interface{})
-	require.True(t, ok, "must have cache key")
-	assert.Contains(t, cache, "path")
+	raw := runSystemRaw(t)
+	cache := cacheFromRaw(t, raw)
 	assert.NotEmpty(t, cache["path"])
+	assert.Equal(t, float64(12345), cache["size"])
+	assert.Contains(t, cache, "max-size")
 }
 
 func TestSystemSubcommandUnsupportedFormat(t *testing.T) {
@@ -72,27 +96,67 @@ func TestSystemSubcommandUnsupportedFormat(t *testing.T) {
 	require.EqualError(t, err, `unsupported format "xml", supported formats: yaml, json`)
 }
 
-func TestSystemSubcommandCachePathMatchesDefault(t *testing.T) {
-	restore := main.MockOsArgs([]string{"system", "--format=json"})
+func TestSystemSubcommandCacheMaxSizeFromFile(t *testing.T) {
+	xdgCache := t.TempDir()
+	cacheDir := filepath.Join(xdgCache, "image-builder", "store")
+	require.NoError(t, os.MkdirAll(cacheDir, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(cacheDir, "cache.size"), []byte("21474836480\n"), 0644))
+
+	restore := main.MockGetCacheDir(func() string {
+		return cacheDir
+	})
 	defer restore()
 
-	var fakeStdout bytes.Buffer
-	restore = main.MockOsStdout(&fakeStdout)
+	restore = main.MockDirSize(func(string) (int64, error) {
+		return 1500, nil
+	})
 	defer restore()
 
-	err := main.Run()
-	require.NoError(t, err)
+	raw := runSystemRaw(t)
+	cache := cacheFromRaw(t, raw)
+	assert.Equal(t, float64(21474836480), cache["max-size"])
+}
 
-	var parsed struct {
-		System struct {
-			Cache struct {
-				Path string `json:"path"`
-			} `json:"cache"`
-		} `json:"system"`
-	}
-	err = json.Unmarshal(fakeStdout.Bytes(), &parsed)
-	require.NoError(t, err)
+func TestSystemSubcommandCacheMaxSizeZeroIsUnlimited(t *testing.T) {
+	xdgCache := t.TempDir()
+	cacheDir := filepath.Join(xdgCache, "image-builder", "store")
+	require.NoError(t, os.MkdirAll(cacheDir, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(cacheDir, "cache.size"), []byte("0\n"), 0644))
 
-	assert.Equal(t, main.CacheDirForUid(0), "/var/cache/image-builder/store")
-	assert.NotEmpty(t, parsed.System.Cache.Path)
+	restore := main.MockGetCacheDir(func() string {
+		return cacheDir
+	})
+	defer restore()
+
+	restore = main.MockDirSize(func(string) (int64, error) {
+		return 0, nil
+	})
+	defer restore()
+
+	raw := runSystemRaw(t)
+	cache := cacheFromRaw(t, raw)
+	assert.Equal(t, "unlimited", cache["max-size"])
+}
+
+func TestSystemSubcommandCacheMaxSizeNoFileIsUnknown(t *testing.T) {
+	restore := main.MockDirSize(func(string) (int64, error) {
+		return 0, nil
+	})
+	defer restore()
+
+	raw := runSystemRaw(t)
+	cache := cacheFromRaw(t, raw)
+	assert.Equal(t, "unknown", cache["max-size"])
+}
+
+func TestSystemSubcommandCacheDirNotExist(t *testing.T) {
+	restore := main.MockDirSize(func(string) (int64, error) {
+		return 0, os.ErrNotExist
+	})
+	defer restore()
+
+	raw := runSystemRaw(t)
+	cache := cacheFromRaw(t, raw)
+	assert.Equal(t, float64(0), cache["size"])
+	assert.Equal(t, "unknown", cache["max-size"])
 }


### PR DESCRIPTION
Let's add a `system` subcommand that (initially) shows information about the cache location, its max-size and its current size.

This will be a good umbrella subcommand to hang other commands under such as `prune` to clear cache in the future. 

```
€ sudo ./image-builder system
system:
  cache:
    path: /var/cache/image-builder/store
    size: 388024255
    max-size: unlimited
```