### PR TITLE
main: don't accept multiple `--blueprint`

### DIFF
--- a/cmd/image-builder/main.go
+++ b/cmd/image-builder/main.go
@@ -41,6 +41,29 @@ var (
 	bootcResolveInfo           = bootc.ResolveBootcInfo
 )
 
+type setOnceString struct {
+	name string
+	val  string
+	set  bool
+}
+
+func (s *setOnceString) String() string {
+	return s.val
+}
+
+func (s *setOnceString) Set(v string) error {
+	if s.set {
+		return fmt.Errorf("flag %q cannot be set more than once", s.name)
+	}
+	s.val = v
+	s.set = true
+	return nil
+}
+
+func (s *setOnceString) Type() string {
+	return "string"
+}
+
 // cacheDirForUid returns the cache directory for the given uid.
 // When root (uid 0) it uses the system-wide /var/cache path.
 // When non-root it follows the XDG Base Directory specification
@@ -746,7 +769,7 @@ operating systems like Fedora, CentOS and RHEL with easy customizations support.
 		Args:         cobra.ExactArgs(1),
 		Hidden:       true,
 	}
-	manifestCmd.Flags().String("blueprint", "", `filename of a blueprint to customize an image`)
+	manifestCmd.Flags().Var(&setOnceString{name: "blueprint"}, "blueprint", `filename of a blueprint to customize an image`)
 	manifestCmd.Flags().Int64("seed", 0, `rng seed, some values are derived randomly, pinning the seed allows more reproducibility if you need it. must be an integer. only used when changed.`)
 	manifestCmd.Flags().String("arch", "", `build manifest for a different architecture`)
 	manifestCmd.Flags().String("distro", "", `build manifest for a different distroname (e.g. centos-9)`)

--- a/cmd/image-builder/main_test.go
+++ b/cmd/image-builder/main_test.go
@@ -1185,6 +1185,19 @@ image_types:
 	}
 }
 
+func TestBlueprintCannotBeSetTwice(t *testing.T) {
+	restore := main.MockOsArgs([]string{
+		"build",
+		"qcow2",
+		"--blueprint=/dev/null",
+		"--blueprint=/dev/null",
+	})
+	defer restore()
+
+	err := main.Run()
+	require.ErrorContains(t, err, `flag "blueprint" cannot be set more than once`)
+}
+
 func TestCacheDirForUidRoot(t *testing.T) {
 	assert.Equal(t, "/var/cache/image-builder/store", main.CacheDirForUid(0))
 }


### PR DESCRIPTION
Cobra by default lets us pass string values multiple times and uses the last one. This is confusing and was reported to be confusing on the `--blueprint` flag.

Let's address it there with a new type that only allows a single value to be set. We might want to expand this to all string-type flags.

Closes #532.