### PR TITLE
cicd: modernize gobump config

### DIFF
--- a/.github/workflows/gobump.yaml
+++ b/.github/workflows/gobump.yaml
@@ -8,30 +8,50 @@ on:  # yamllint disable-line rule:truthy
     - cron: "0 6 * * 1"
 
 jobs:
-  bump-deps-only-images:
+  update-and-push:
     runs-on: ubuntu-latest
+    container: registry.fedoraproject.org/fedora:43
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v6
+      - name: Prepare environment and run tests
+        run: |
+          set -xe
+          sudo dnf -y install git gh jq golang skopeo libvirt-devel gpgme-devel btrfs-progs-devel krb5-devel
+          git clone --depth 1 https://github.com/osbuild/image-builder-cli
+          cd image-builder-cli/
+          make build test
 
-      - name: Run gobump-deps action - images
-        uses: lzap/gobump@main
-        with:
-          go_version: "1.24.12"
-          token: ${{ secrets.SCHUTZBOT_GITHUB_ACCESS_TOKEN }}
-          include: "github.com/osbuild/images github.com/osbuild/blueprint"
-          commit_message: "deps: bump osbuild/images dependency"
+      - name: Run gobump and open a PR
+        env:
+          GH_TOKEN: ${{ secrets.SCHUTZBOT_GITHUB_ACCESS_TOKEN }}
+        run: |
+          set -xe
+          cd image-builder-cli/
+          git config user.name "schutzbot"
+          git config user.email "schutzbot@gmail.com"
+          branch="schutz-gobump-$(date -I)"
+          git checkout -b "${branch}"
+          go run github.com/lzap/gobump@latest \
+            -exec "./tools/prepare-source.sh" \
+            -exec "make build test" \
+            -verbose -format markdown | tee "/tmp/github_pr_body.txt"
 
-  bump-deps-without-images:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v6
+          # Check and update spec file version if needed
+          IMAGES_DIR=$(go mod download -json github.com/osbuild/images | jq -r '.Dir')
+          REQUIRED_VERSION=$(cat "${IMAGES_DIR}/data/dependencies/osbuild" | tr -d '[:space:]')
+          CURRENT_VERSION=$(grep '^%global min_osbuild_version' image-builder.spec | awk '{print $3}')
+          if [ "${CURRENT_VERSION}" != "${REQUIRED_VERSION}" ]; then
+            sed -i "s/^%global min_osbuild_version .*/%global min_osbuild_version ${REQUIRED_VERSION}/" image-builder.spec
+            git add image-builder.spec
+            git commit -m "chore: update spec with new images minimum version"
+          else
+            echo "Spec file version is already up to date (${CURRENT_VERSION})"
+          fi
 
-      - name: Run gobump-deps action - all other
-        uses: lzap/gobump@main
-        with:
-          go_version: "1.24.12"
-          token: ${{ secrets.SCHUTZBOT_GITHUB_ACCESS_TOKEN }}
-          exclude: "github.com/osbuild/images,github.com/osbuild/blueprint"
-          commit_message: "deps: update dependencies (w/o osbuild/images)"
+          git log --oneline "main..${branch}"
+          git push -f "https://$GH_TOKEN@github.com/schutzbot/image-builder-cli.git" "${branch}"
+          gh pr create \
+            -t "Update dependencies $(date -I)" \
+            -F "/tmp/github_pr_body.txt" \
+            --repo "osbuild/image-builder-cli" \
+            --base "main" \
+            --head "schutzbot:${branch}"


### PR DESCRIPTION
This is a port of gobump config from composer/images. It is exactly the same, but since I could not find the osbuild minimum version in this project, Claude figured out a hacky but nice way to parse it out of the images dependency. So for each gobump PR there will be automatically also update of the minimum version as well. Not sure if this is something we want to do tho - can drop it.