### PR TITLE
Re-enable the bootc-image-builder tests

### DIFF
--- a/.github/workflows/bibtests.yaml
+++ b/.github/workflows/bibtests.yaml
@@ -1,0 +1,118 @@
+---
+name: Bib tests
+
+on:  # yamllint disable-line rule:truthy
+  pull_request:
+    branches:
+      - "*"
+  push:
+    branches:
+      - "main"
+  # for merge queue
+  merge_group:
+
+env:
+  GO_VERSION: 1.24.12
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  collect_tests:
+    runs-on: ubuntu-latest
+    outputs:
+      test_files: ${{ steps.collect.outputs.test_files }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+      - name: Collect test files
+        id: collect
+        run: |
+          TEST_FILES=$(ls test/bib/test_*.py | sort)
+          JSON_FILES=$(echo "${TEST_FILES}" | jq -R | jq -cs )
+          echo "test_files=${JSON_FILES}" >> $GITHUB_OUTPUT
+
+  integration:
+    name: "Integration"
+    runs-on: ubuntu-24.04
+    needs: collect_tests
+    strategy:
+      matrix:
+        test_file: ${{ fromJson(needs.collect_tests.outputs.test_files) }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+      - name: Setup up python
+        uses: actions/setup-python@v6
+      - name: Apt update
+        run: sudo apt update
+      - name: Install test dependencies
+        run: |
+          sudo apt update
+          sudo apt install -y python3-pytest python3-boto3 flake8 pylint libosinfo-bin squashfs-tools sshpass
+      - name: Diskspace (before)
+        run: |
+          df -h
+          sudo du -sh * /var/tmp /tmp /var/lib/containers | sort -sh
+      - name: Free Disk Space
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be
+        with:
+          tool-cache: true
+          # The following line runs apt remove which is slow
+          large-packages: false
+      - name: Workaround podman issues in GH actions
+        run: |
+          # see https://github.com/osbuild/bootc-image-builder/issues/446
+          sudo rm -rf /var/lib/containers/storage
+          sudo mkdir -p /etc/containers
+          echo -e "[storage]\ndriver = \"overlay\"\nrunroot = \"/run/containers/storage\"\ngraphroot = \"/var/lib/containers/storage\"" | sudo tee /etc/containers/storage.conf
+      - name: Updating qemu-user
+        run: |
+          # get qemu-9 with openat2 patches via qemu-user-static, that
+          # has no dependencies so just install.
+          # XXX: remove once ubuntu ships qemu-9.1
+          sudo apt install -y software-properties-common
+          sudo apt-add-repository -y ppa:mvo/qemu
+          sudo apt install --no-install-recommends -y qemu-user-static
+          # Now remove ppa again, the metadata confuses apt. Then install
+          # qemu-system-* from the regular repo again.
+          sudo apt-add-repository --remove -y ppa:mvo/qemu
+          sudo apt install -y qemu-system-arm qemu-system-x86 qemu-efi-aarch64
+      - name: Install python test deps
+        run: |
+          # make sure test deps are available for root
+          sudo -E pip install --user -r test/bib/requirements.txt
+      - name: Workarounds for GH runner diskspace
+        run: |
+          # use custom basetemp here because /var/tmp is on a smaller disk
+          # than /mnt
+          sudo mkdir -p /mnt/var/tmp/bib-tests
+          # on GH runners /mnt has 70G free space, use that for our container
+          # storage
+          sudo mkdir -p /mnt/var/lib/containers
+          sudo mount -o bind /mnt/var/lib/containers /var/lib/containers
+      - run: |
+          mkdir -p /var/tmp/osbuild-test-store
+      - name: Cache osbuild env
+        uses: actions/cache@v5
+        with:
+          path: /var/tmp/osbuild-test-store
+          key: no-key-needed-here
+      - name: Run tests
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        run: |
+          # podman needs (parts of) the environment but will break when
+          # XDG_RUNTIME_DIR is set.
+          # TODO: figure out what exactly podman needs
+          sudo -E XDG_RUNTIME_DIR= PYTHONPATH=. pytest-3 -v --basetemp=/mnt/var/tmp/bib-tests ${{ matrix.test_file }}
+      - name: Diskspace (after)
+        if: ${{ always() }}
+        run: |
+          df -h
+          sudo du -sh * /var/tmp /tmp /var/lib/containers | sort -sh

--- a/test/bib/README.md
+++ b/test/bib/README.md
@@ -1,0 +1,21 @@
+bootc-image-builder
+-------------------
+
+This directory contains integration tests copied from [bootc-image-builder](https://github.com/osbuild/bootc-image-builder). The project was merged into image-builder (this repo).
+
+They can be run in two ways
+1. On the local machine:
+ By just running `sudo pytest -s -v` in the _top level folder_ of the project (where `Containerfile` is)
+ If you have set up `pip` only for your user, you might just want to run the test with elevated privileges
+ `sudo -E $(which pytest) -s -v`
+2. Via `tmt` [0] which will spin up a clean VM and run the tests inside:
+
+	tmt run -vvv
+
+[0] https://github.com/teemtee/tmt
+
+To install `tmt` on fedora at least those packages are needed:
+
+```shell
+sudo dnf install tmt tmt+provision-virtual
+```


### PR DESCRIPTION
Start running the bib (bootc-image-builder) tests again to prepare for finalising the merge.